### PR TITLE
Fix MSVC build

### DIFF
--- a/include/ClapFile.h
+++ b/include/ClapFile.h
@@ -57,9 +57,9 @@ public:
 	explicit ClapFile(fs::path filename);
 	~ClapFile();
 
-	ClapFile(const ClapFile&) = delete;
+	ClapFile(const ClapFile&) = default;
 	ClapFile(ClapFile&& other) noexcept;
-	auto operator=(const ClapFile&) -> ClapFile& = delete;
+	auto operator=(const ClapFile&) -> ClapFile& = default;
 	auto operator=(ClapFile&& rhs) noexcept -> ClapFile&;
 
 	//! Loads the .clap file and scans for plugins
@@ -86,7 +86,7 @@ private:
 
 	struct EntryDeleter
 	{
-		void operator()(const clap_plugin_entry* p) const
+		void operator()(const clap_plugin_entry* p) const noexcept
 		{
 			p->deinit();
 		}

--- a/include/ClapFile.h
+++ b/include/ClapFile.h
@@ -40,48 +40,28 @@
 namespace lmms
 {
 
-//! Class representing info for one .clap file, which contains 1 or more CLAP plugins
+//! Manages a .clap file, each of which may contain multiple plugins
 class LMMS_EXPORT ClapFile
 {
 public:
 	//! passkey idiom
-	class LMMS_EXPORT AccessKey
+	class Access
 	{
 	public:
-		AccessKey(AccessKey&&) noexcept = default;
 		friend class ClapManager;
+		Access(Access&&) noexcept = default;
 	private:
-		AccessKey() {}
-		AccessKey(const AccessKey&) = default;
+		Access() {}
+		Access(const Access&) = default;
 	};
 
 	explicit ClapFile(fs::path filename);
 	~ClapFile();
 
 	ClapFile(const ClapFile&) = delete;
-	ClapFile(ClapFile&& other) noexcept
-		: m_filename{std::move(other.m_filename)}
-		, m_library{std::move(other.m_library)}
-		, m_entry{std::move(other.m_entry)}
-		, m_factory{other.m_factory}
-		, m_pluginInfo{std::move(other.m_pluginInfo)}
-		, m_pluginCount{other.m_pluginCount}
-	{
-	}
+	ClapFile(ClapFile&&) noexcept = default;
 	auto operator=(const ClapFile&) -> ClapFile& = delete;
-	auto operator=(ClapFile&& rhs) noexcept -> ClapFile&
-	{
-		if (this != &rhs)
-		{
-			m_filename = std::move(rhs.m_filename);
-			m_library = std::move(rhs.m_library);
-			m_entry = std::move(rhs.m_entry);
-			m_factory = rhs.m_factory;
-			m_pluginInfo = std::move(rhs.m_pluginInfo);
-			m_pluginCount = rhs.m_pluginCount;
-		}
-		return *this;
-	}
+	auto operator=(ClapFile&&) noexcept -> ClapFile& = default;
 
 	//! Loads the .clap file and scans for plugins
 	auto load() -> bool;
@@ -93,7 +73,7 @@ public:
 	auto pluginInfo() const -> auto& { return m_pluginInfo; }
 
 	//! Only includes plugins that successfully loaded; Some may be invalidated later
-	auto pluginInfo(AccessKey) -> auto& { return m_pluginInfo; }
+	auto pluginInfo(Access) -> auto& { return m_pluginInfo; }
 
 	//! Includes plugins that failed to load
 	auto pluginCount() const { return m_pluginCount; }

--- a/include/ClapFile.h
+++ b/include/ClapFile.h
@@ -47,20 +47,41 @@ public:
 	//! passkey idiom
 	class AccessKey
 	{
-		AccessKey() {}
-		AccessKey(const AccessKey&) = default;
 	public:
 		AccessKey(AccessKey&&) noexcept = default;
 		friend class ClapManager;
+	private:
+		AccessKey() {}
+		AccessKey(const AccessKey&) = default;
 	};
 
 	explicit ClapFile(fs::path filename);
 	~ClapFile();
 
 	ClapFile(const ClapFile&) = default;
-	ClapFile(ClapFile&& other) noexcept;
+	ClapFile(ClapFile&& other) noexcept
+		: m_filename{std::move(other.m_filename)}
+		, m_library{std::move(other.m_library)}
+		, m_entry{std::move(other.m_entry)}
+		, m_factory{other.m_factory}
+		, m_pluginInfo{std::move(other.m_pluginInfo)}
+		, m_pluginCount{other.m_pluginCount}
+	{
+	}
 	auto operator=(const ClapFile&) -> ClapFile& = default;
-	auto operator=(ClapFile&& rhs) noexcept -> ClapFile&;
+	auto operator=(ClapFile&& rhs) noexcept -> ClapFile&
+	{
+		if (this != &rhs)
+		{
+			m_filename = std::move(rhs.m_filename);
+			m_library = std::move(rhs.m_library);
+			m_entry = std::move(rhs.m_entry);
+			m_factory = rhs.m_factory;
+			m_pluginInfo = std::move(rhs.m_pluginInfo);
+			m_pluginCount = rhs.m_pluginCount;
+		}
+		return *this;
+	}
 
 	//! Loads the .clap file and scans for plugins
 	auto load() -> bool;

--- a/include/ClapFile.h
+++ b/include/ClapFile.h
@@ -45,7 +45,7 @@ class LMMS_EXPORT ClapFile
 {
 public:
 	//! passkey idiom
-	class AccessKey
+	class LMMS_EXPORT AccessKey
 	{
 	public:
 		AccessKey(AccessKey&&) noexcept = default;
@@ -58,7 +58,7 @@ public:
 	explicit ClapFile(fs::path filename);
 	~ClapFile();
 
-	ClapFile(const ClapFile&) = default;
+	ClapFile(const ClapFile&) = delete;
 	ClapFile(ClapFile&& other) noexcept
 		: m_filename{std::move(other.m_filename)}
 		, m_library{std::move(other.m_library)}
@@ -68,7 +68,7 @@ public:
 		, m_pluginCount{other.m_pluginCount}
 	{
 	}
-	auto operator=(const ClapFile&) -> ClapFile& = default;
+	auto operator=(const ClapFile&) -> ClapFile& = delete;
 	auto operator=(ClapFile&& rhs) noexcept -> ClapFile&
 	{
 		if (this != &rhs)

--- a/include/ClapManager.h
+++ b/include/ClapManager.h
@@ -73,7 +73,7 @@ private:
 	//! For hashing since std::hash<std::filesystem::path> is not available until C++23's LWG issue 3657 for god knows why
 	struct PathHash
 	{
-		auto operator()(const fs::path& path) const -> std::size_t
+		auto operator()(const fs::path& path) const noexcept -> std::size_t
 		{
 			return fs::hash_value(path);
 		}

--- a/include/ClapManager.h
+++ b/include/ClapManager.h
@@ -91,7 +91,7 @@ private:
 	void loadClapFiles(const UniquePaths& searchPaths);
 
 	UniquePaths m_searchPaths; //!< Owns all CLAP search paths; Populated by findSearchPaths()
-	std::vector<std::unique_ptr<ClapFile>> m_files; //!< Owns all loaded .clap files; Populated by loadClapFiles()
+	std::vector<ClapFile> m_files; //!< Owns all loaded .clap files; Populated by loadClapFiles()
 
 	// Non-owning plugin caches (for fast iteration/lookup)
 

--- a/include/ClapManager.h
+++ b/include/ClapManager.h
@@ -37,13 +37,14 @@
 #include <vector>
 
 #include "ClapFile.h"
+#include "NoCopyNoMove.h"
 #include "lmms_export.h"
 
 namespace lmms
 {
 
 //! Manages loaded .clap files, plugin info, and plugin instances
-class LMMS_EXPORT ClapManager
+class LMMS_EXPORT ClapManager : public NoCopyNoMove
 {
 public:
 	ClapManager();

--- a/include/ClapPluginInfo.h
+++ b/include/ClapPluginInfo.h
@@ -49,6 +49,11 @@ public:
 	ClapPluginInfo() = delete;
 	~ClapPluginInfo() = default;
 
+	ClapPluginInfo(const ClapPluginInfo&) = default;
+	ClapPluginInfo(ClapPluginInfo&&) noexcept = default;
+	auto operator=(const ClapPluginInfo&) -> ClapPluginInfo& = default;
+	auto operator=(ClapPluginInfo&&) noexcept -> ClapPluginInfo& = default;
+
 	auto factory() const -> const clap_plugin_factory& { return *m_factory; };
 	auto index() const { return m_index; }
 	auto type() const { return m_type; }

--- a/include/ClapPluginInfo.h
+++ b/include/ClapPluginInfo.h
@@ -46,12 +46,8 @@ public:
 	//! Creates plugin info, populated via a quick scan of the plugin; may fail
 	static auto create(const clap_plugin_factory& factory, std::uint32_t index) -> std::optional<ClapPluginInfo>;
 
+	ClapPluginInfo() = delete;
 	~ClapPluginInfo() = default;
-
-	ClapPluginInfo(const ClapPluginInfo&) = default;
-	ClapPluginInfo(ClapPluginInfo&&) noexcept = default;
-	auto operator=(const ClapPluginInfo&) -> ClapPluginInfo& = default;
-	auto operator=(ClapPluginInfo&&) noexcept -> ClapPluginInfo& = default;
 
 	auto factory() const -> const clap_plugin_factory& { return *m_factory; };
 	auto index() const { return m_index; }

--- a/src/core/clap/ClapFile.cpp
+++ b/src/core/clap/ClapFile.cpp
@@ -42,30 +42,6 @@ ClapFile::~ClapFile()
 	unload();
 }
 
-ClapFile::ClapFile(ClapFile&& other) noexcept
-	: m_filename{std::move(other.m_filename)}
-	, m_library{std::move(other.m_library)}
-	, m_entry{std::move(other.m_entry)}
-	, m_factory{other.m_factory}
-	, m_pluginInfo{std::move(other.m_pluginInfo)}
-	, m_pluginCount{other.m_pluginCount}
-{
-}
-
-auto ClapFile::operator=(ClapFile&& rhs) noexcept -> ClapFile&
-{
-	if (this != &rhs)
-	{
-		m_filename = std::move(rhs.m_filename);
-		m_library = std::move(rhs.m_library);
-		m_entry = std::move(rhs.m_entry);
-		m_factory = rhs.m_factory;
-		m_pluginInfo = std::move(rhs.m_pluginInfo);
-		m_pluginCount = rhs.m_pluginCount;
-	}
-	return *this;
-}
-
 auto ClapFile::load() -> bool
 {
 	// Do not allow reloading yet

--- a/src/core/clap/ClapFile.cpp
+++ b/src/core/clap/ClapFile.cpp
@@ -141,12 +141,6 @@ void ClapFile::unload() noexcept
 	}
 }
 
-void ClapFile::EntryDeleter::operator()(const clap_plugin_entry* ptr) const
-{
-	// No more calls into the shared library can be made after this
-	ptr->deinit();
-}
-
 } // namespace lmms
 
 #endif // LMMS_HAVE_CLAP

--- a/src/core/clap/ClapFile.cpp
+++ b/src/core/clap/ClapFile.cpp
@@ -141,7 +141,7 @@ void ClapFile::unload() noexcept
 	}
 }
 
-void ClapFile::EntryDeleter::operator()(const clap_plugin_entry* ptr)
+void ClapFile::EntryDeleter::operator()(const clap_plugin_entry* ptr) const
 {
 	// No more calls into the shared library can be made after this
 	ptr->deinit();

--- a/src/core/clap/ClapManager.cpp
+++ b/src/core/clap/ClapManager.cpp
@@ -227,7 +227,7 @@ void ClapManager::loadClapFiles(const UniquePaths& searchPaths)
 			}
 
 			totalPlugins += file->pluginCount();
-			for (auto& plugin : file->pluginInfo(ClapFile::AccessKey{}))
+			for (auto& plugin : file->pluginInfo({}))
 			{
 				assert(plugin.has_value());
 				const bool added = m_uriMap.emplace(std::string{plugin->descriptor().id}, *plugin).second;

--- a/src/core/clap/ClapManager.cpp
+++ b/src/core/clap/ClapManager.cpp
@@ -215,19 +215,19 @@ void ClapManager::loadClapFiles(const UniquePaths& searchPaths)
 				ClapLog::plainLog(msg);
 			}
 
-			auto& file = m_files.emplace_back(std::make_unique<ClapFile>(entryPath));
-			if (!file || !file->load())
+			auto& file = m_files.emplace_back(std::move(entryPath));
+			if (!file.load())
 			{
 				std::string msg = "Failed to load '";
-				msg += entryPath.string();
+				msg += file.filename().string();
 				msg += "'";
 				ClapLog::globalLog(CLAP_LOG_ERROR, msg);
 				m_files.pop_back(); // Remove/unload invalid clap file
 				continue;
 			}
 
-			totalPlugins += file->pluginCount();
-			for (auto& plugin : file->pluginInfo({}))
+			totalPlugins += file.pluginCount();
+			for (auto& plugin : file.pluginInfo({}))
 			{
 				assert(plugin.has_value());
 				const bool added = m_uriMap.emplace(std::string{plugin->descriptor().id}, *plugin).second;

--- a/src/core/clap/ClapManager.cpp
+++ b/src/core/clap/ClapManager.cpp
@@ -198,7 +198,7 @@ void ClapManager::loadClapFiles(const UniquePaths& searchPaths)
 	{
 		for (const auto& entry : fs::recursive_directory_iterator{path})
 		{
-			const auto& entryPath = entry.path();
+			auto& entryPath = entry.path();
 			std::error_code ec;
 			// NOTE: Using is_regular_file() free function workaround due to std::experimental::filesystem
 			if (!fs::is_regular_file(entry, ec) || entryPath.extension() != ".clap")

--- a/src/core/clap/ClapPluginInfo.cpp
+++ b/src/core/clap/ClapPluginInfo.cpp
@@ -35,7 +35,7 @@ namespace lmms
 auto ClapPluginInfo::create(const clap_plugin_factory& factory, std::uint32_t index) -> std::optional<ClapPluginInfo>
 {
 	auto info = std::optional{ClapPluginInfo{factory, index}};
-	return info->type() != Plugin::Type::Undefined ? std::move(info) : std::nullopt;
+	return info->type() != Plugin::Type::Undefined ? info : std::nullopt;
 }
 
 ClapPluginInfo::ClapPluginInfo(const clap_plugin_factory& factory, std::uint32_t index)

--- a/src/core/clap/ClapPluginInfo.cpp
+++ b/src/core/clap/ClapPluginInfo.cpp
@@ -35,7 +35,7 @@ namespace lmms
 auto ClapPluginInfo::create(const clap_plugin_factory& factory, std::uint32_t index) -> std::optional<ClapPluginInfo>
 {
 	auto info = std::optional{ClapPluginInfo{factory, index}};
-	return info->type() != Plugin::Type::Undefined ? info : std::nullopt;
+	return info->type() != Plugin::Type::Undefined ? std::move(info) : std::nullopt;
 }
 
 ClapPluginInfo::ClapPluginInfo(const clap_plugin_factory& factory, std::uint32_t index)

--- a/src/core/clap/ClapSubPluginFeatures.cpp
+++ b/src/core/clap/ClapSubPluginFeatures.cpp
@@ -108,9 +108,7 @@ void ClapSubPluginFeatures::listSubPluginKeys(const Plugin::Descriptor* desc, Ke
 {
 	for (const auto& file : Engine::getClapManager()->files())
 	{
-		if (!file) { continue; }
-
-		for (const auto& info : file->pluginInfo())
+		for (const auto& info : file.pluginInfo())
 		{
 			if (!info || info->type() != m_type) { continue; }
 


### PR DESCRIPTION
MSVC builds were failing when trying to compile `include/ClapManager.h` included from `src/core/Engine.cpp`.

It was trying to create a default copy constructor or copy assignment operator for the `ClapManager` class which contained a move-only member (the vector of `ClapFile` objects) - even though I never tried to copy or move `ClapManager` anywhere in my code.

When I explicitly deleted the copy/move constructors and copy/move assignment operators for `ClapManager` by inheriting `NoCopyNoMove`, it fixed the issue. The weird part is that it worked before with a different yet still move-only class layout.

Maybe it's an MSVC bug, since the GCC, Clang, and MinGW builds were successful even without explicitly deleting the copy/move constructors and copy/move assignment operators.