### PR TITLE
Plugin audio ports

### DIFF
--- a/include/AudioData.h
+++ b/include/AudioData.h
@@ -64,7 +64,7 @@ inline constexpr int DynamicChannelCount = -1;
 
 
 /**
- * Non-owning view for multi-channel "split" (non-interleaved) audio data
+ * Non-owning view for multi-channel non-interleaved audio data
  *
  * TODO C++23: Use std::mdspan
  */

--- a/include/AudioData.h
+++ b/include/AudioData.h
@@ -153,16 +153,6 @@ public:
 	{
 	}
 
-	//! Dynamic channel count to static channel count; use with care
-	template<int thisChannelCount, std::enable_if_t<(channelCount == DynamicChannelCount), bool> = true>
-	explicit SplitAudioData(const SplitAudioData<SampleT, thisChannelCount>& other)
-		: m_data{other.data()}
-		, m_channels{thisChannelCount}
-		, m_frames{other.frames()}
-	{
-		assert(thisChannelCount <= other.channels());
-	}
-
 	/**
 	 * Returns pointer to the buffer of a given channel.
 	 * The size of the buffer is `frames()`.

--- a/include/AudioData.h
+++ b/include/AudioData.h
@@ -1,7 +1,7 @@
 /*
  * AudioData.h - Audio data types
  *
- * Copyright (c) 2024 Dalton Messmer <messmer.dalton/at/gmail.com>
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -33,8 +33,32 @@
 namespace lmms
 {
 
+
+//! Types of audio data supported in LMMS
+enum class AudioDataKind : std::uint8_t
+{
+	SampleFrame,
+	F32,
+	// F64,
+	// I16,
+	// etc.
+};
+
+namespace detail {
+
+//! Specialize this struct to enable
+template<AudioDataKind kind> struct AudioDataType;
+
+template<> struct AudioDataType<AudioDataKind::F32> { using type = float; };
+
+} // namespace detail
+
+//! Metafunction to convert `AudioDataKind` to its type
+template<AudioDataKind kind>
+using GetAudioDataType = typename detail::AudioDataType<kind>::type;
+
 //! Conventions for passing audio data
-enum class AudioDataLayout
+enum class AudioDataLayout : bool
 {
 	/**
 	 * Given:

--- a/include/AudioData.h
+++ b/include/AudioData.h
@@ -59,24 +59,6 @@ template<AudioDataKind kind>
 using GetAudioDataType = typename detail::AudioDataType<kind>::type;
 
 
-/**
- * A simple type alias for floating point audio data types which documents the data layout.
- *
- * For example, `const InterleavedSampleType<sample_t>*` can be used as a replacement for `const sample_t*`
- * parameters in order to document that the data layout of the audio is interleaved.
- *
- * NOTE: Can add support for integer sample types later
- */
-template<bool interleaved, typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
-using SampleType = T;
-
-template<typename T>
-using SplitSampleType = SampleType<false, T>;
-
-template<typename T>
-using InterleavedSampleType = SampleType<true, T>;
-
-
 //! Use when the number of channels is not known at compile time
 inline constexpr int DynamicChannelCount = -1;
 
@@ -98,7 +80,7 @@ public:
 	 *  data[channels][frames]
 	 * Each buffer contains `frames` frames.
 	 */
-	SplitAudioData(SplitSampleType<SampleT>* const* data, pi_ch_t channels, f_cnt_t frames)
+	SplitAudioData(SampleT* const* data, pi_ch_t channels, f_cnt_t frames)
 		: m_data{data}
 		, m_channels{channels}
 		, m_frames{frames}
@@ -119,7 +101,7 @@ public:
 	 * Returns pointer to the buffer of a given channel.
 	 * The size of the buffer is `frames()`.
 	 */
-	auto buffer(pi_ch_t channel) const -> SplitSampleType<SampleT>*
+	auto buffer(pi_ch_t channel) const -> SampleT*
 	{
 		assert(channel < m_channels);
 		assert(m_data != nullptr);
@@ -127,7 +109,7 @@ public:
 	}
 
 	template<pi_ch_t channel>
-	auto buffer() const -> SplitSampleType<SampleT>*
+	auto buffer() const -> SampleT*
 	{
 		static_assert(channel != DynamicChannelCount);
 		static_assert(channel < channelCount);
@@ -156,16 +138,16 @@ public:
 	 *     contiguous buffer for all channels whose size is channels() * frames().
 	 *     Whether this is true depends on the implementation of the source buffer.
 	 */
-	auto sourceBuffer() const -> Span<SplitSampleType<SampleT>>
+	auto sourceBuffer() const -> Span<SampleT>
 	{
 		assert(m_data != nullptr);
-		return Span<SplitSampleType<SampleT>>{m_data[0], channels() * frames()};
+		return Span<SampleT>{m_data[0], channels() * frames()};
 	}
 
-	auto data() const -> SplitSampleType<SampleT>* const* { return m_data; }
+	auto data() const -> SampleT* const* { return m_data; }
 
 private:
-	SplitSampleType<SampleT>* const* m_data = nullptr;
+	SampleT* const* m_data = nullptr;
 	pi_ch_t m_channels = 0;
 	f_cnt_t m_frames = 0;
 };

--- a/include/AudioPlugin.h
+++ b/include/AudioPlugin.h
@@ -368,7 +368,7 @@ private:
  *
  * @param ParentT Either `Instrument` or `Effect`
  * @param config Compile time configuration to customize `AudioPlugin`
- * @param AudioPortT The audio port - must implement `PluginAudioPort`
+ * @param AudioPortT The plugin's audio port - must fully implement `PluginAudioPort`
  */
 template<class ParentT, AudioPluginConfig config, class AudioPortT = DefaultPluginAudioPort<config>>
 class AudioPlugin

--- a/include/AudioPlugin.h
+++ b/include/AudioPlugin.h
@@ -2,7 +2,7 @@
  * AudioPlugin.h - Interface for audio plugins which provides
  *                 pin connector support and compile-time customizations
  *
- * Copyright (c) 2024 Dalton Messmer <messmer.dalton/at/gmail.com>
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -26,13 +26,13 @@
 #ifndef LMMS_AUDIO_PLUGIN_H
 #define LMMS_AUDIO_PLUGIN_H
 
+#include <type_traits>
 #include "AudioData.h"
-#include "AudioPluginBuffer.h"
+#include "AudioPluginConfig.h"
 #include "Effect.h"
 #include "Instrument.h"
 #include "InstrumentTrack.h"
-#include "PluginPinConnector.h"
-#include "SampleFrame.h"
+#include "PluginAudioPort.h"
 
 namespace lmms
 {
@@ -49,37 +49,18 @@ enum class ProcessStatus
 	Sleep
 };
 
-//! Compile time customizations for `AudioPlugin` to meet the needs of a plugin implementation
-struct PluginConfig
-{
-	//! The audio data layout used by the plugin
-	AudioDataLayout layout;
-
-	//! The number of plugin input channels, or `DynamicChannelCount` if unknown at compile time
-	int inputs = DynamicChannelCount;
-
-	//! The number of plugin output channels, or `DynamicChannelCount` if unknown at compile time
-	int outputs = DynamicChannelCount;
-
-	//! In-place processing - true (always in-place) or false (dynamic, customizable in audio buffer impl)
-	bool inplace = false;
-
-	//! If true, plugin implementation will provide an `AudioPluginBufferInterfaceProvider`
-	bool customBuffer = false;
-};
-
 class NotePlayHandle;
 
 namespace detail
 {
 
 //! Provides the correct `processImpl` interface for instruments or effects to implement
-template<class ParentT, typename BufferT, typename ConstBufferT, bool inplace, bool customBuffer>
+template<class ParentT, typename BufferT, typename ConstBufferT, bool inplace, bool provideBuffers>
 class AudioProcessingMethod;
 
 //! Instrument specialization
 template<typename BufferT, typename ConstBufferT>
-class AudioProcessingMethod<Instrument, BufferT, ConstBufferT, false, false>
+class AudioProcessingMethod<Instrument, BufferT, ConstBufferT, false, true>
 {
 protected:
 	//! The main audio processing method for NotePlayHandle-based Instruments
@@ -92,7 +73,7 @@ protected:
 
 //! Instrument specialization (in-place)
 template<typename BufferT, typename ConstBufferT>
-class AudioProcessingMethod<Instrument, BufferT, ConstBufferT, true, false>
+class AudioProcessingMethod<Instrument, BufferT, ConstBufferT, true, true>
 {
 protected:
 	//! The main audio processing method for NotePlayHandle-based Instruments
@@ -105,7 +86,7 @@ protected:
 
 //! Instrument specialization (custom working buffers)
 template<typename BufferT, typename ConstBufferT, bool inplace>
-class AudioProcessingMethod<Instrument, BufferT, ConstBufferT, inplace, true>
+class AudioProcessingMethod<Instrument, BufferT, ConstBufferT, inplace, false>
 {
 protected:
 	/**
@@ -124,7 +105,7 @@ protected:
 
 //! Effect specialization
 template<typename BufferT, typename ConstBufferT>
-class AudioProcessingMethod<Effect, BufferT, ConstBufferT, false, false>
+class AudioProcessingMethod<Effect, BufferT, ConstBufferT, false, true>
 {
 protected:
 	/**
@@ -136,7 +117,7 @@ protected:
 
 //! Effect specialization (in-place)
 template<typename BufferT, typename ConstBufferT>
-class AudioProcessingMethod<Effect, BufferT, ConstBufferT, true, false>
+class AudioProcessingMethod<Effect, BufferT, ConstBufferT, true, true>
 {
 protected:
 	/**
@@ -148,7 +129,7 @@ protected:
 
 //! Effect specialization (custom working buffers)
 template<typename BufferT, typename ConstBufferT, bool inplace>
-class AudioProcessingMethod<Effect, BufferT, ConstBufferT, inplace, true>
+class AudioProcessingMethod<Effect, BufferT, ConstBufferT, inplace, false>
 {
 protected:
 	/**
@@ -160,60 +141,60 @@ protected:
 };
 
 //! Connects the core audio channels to the instrument or effect using the pin connector
-template<class ParentT, typename SampleT, PluginConfig config>
+template<class ParentT, AudioPluginConfig config, class AudioPortT>
 class AudioPlugin
 {
 	static_assert(always_false_v<ParentT>, "ParentT must be either Instrument or Effect");
 };
 
 //! Instrument specialization
-template<typename SampleT, PluginConfig config>
-class AudioPlugin<Instrument, SampleT, config>
+template<AudioPluginConfig config, class AudioPortT>
+class AudioPlugin<Instrument, config, AudioPortT>
 	: public Instrument
 	, public AudioProcessingMethod<Instrument,
-		typename AudioDataTypeSelector<config.layout, SampleT, config.inputs>::type,
-		typename AudioDataTypeSelector<config.layout, const SampleT, config.outputs>::type,
-		config.inplace, config.customBuffer>
-	, public std::conditional_t<config.customBuffer,
-		AudioPluginBufferInterfaceProvider<config.layout, SampleT, config.inputs, config.outputs>,
-		AudioPluginBufferDefaultImpl<config.layout, SampleT, config.inputs, config.outputs, config.inplace>>
+		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, true>::type,
+		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, false>::type,
+		config.inplace, AudioPortT::provideProcessBuffers()>
 {
 public:
 	AudioPlugin(const Plugin::Descriptor* desc, InstrumentTrack* parent = nullptr,
 		const Plugin::Descriptor::SubPluginFeatures::Key* key = nullptr,
 		Instrument::Flags flags = Instrument::Flag::NoFlags)
 		: Instrument{desc, parent, key, flags}
-		, m_pinConnector{config.inputs, config.outputs, true, this}
+		, m_audioPort{true, this}
 	{
-		connect(&m_pinConnector, &PluginPinConnector::pluginBuffersChanged,
-			this, &AudioPlugin::updatePluginBuffers);
 	}
 
-	auto pinConnector() const -> const PluginPinConnector* final { return &m_pinConnector; }
-
 protected:
+	auto audioPort() -> AudioPortT& { return m_audioPort; }
+
+	auto pinConnector() const -> const PluginPinConnector* final
+	{
+		return m_audioPort.pinConnector();
+	}
+
 	void playImpl(CoreAudioDataMut inOut) final
 	{
 		SampleFrame* temp = inOut.data();
 		const auto bus = CoreAudioBusMut{&temp, 1, inOut.size()};
-		auto bufferInterface = this->bufferInterface();
-		if (!bufferInterface)
+		auto buffers = m_audioPort.buffers();
+		if (!buffers)
 		{
 			// Plugin is not running
 			return;
 		}
 
-		auto router = m_pinConnector.getRouter<config.layout, SampleT, config.inputs, config.outputs>();
+		auto router = m_audioPort.getRouter();
 
 		if constexpr (config.inplace)
 		{
 			// Write core to plugin input buffer
-			const auto pluginInOut = bufferInterface->inputBuffer();
+			const auto pluginInOut = buffers->inputBuffer();
 			router.routeToPlugin(bus, pluginInOut);
 
 			// Process
-			if constexpr (config.customBuffer) { this->processImpl(); }
-			else { this->processImpl(pluginInOut); }
+			if constexpr (AudioPortT::provideProcessBuffers()) { this->processImpl(pluginInOut); }
+			else { this->processImpl(); }
 
 			// Write plugin output buffer to core
 			router.routeFromPlugin(pluginInOut, bus);
@@ -221,13 +202,13 @@ protected:
 		else
 		{
 			// Write core to plugin input buffer
-			const auto pluginIn = bufferInterface->inputBuffer();
-			const auto pluginOut = bufferInterface->outputBuffer();
+			const auto pluginIn = buffers->inputBuffer();
+			const auto pluginOut = buffers->outputBuffer();
 			router.routeToPlugin(bus, pluginIn);
 
 			// Process
-			if constexpr (config.customBuffer) { this->processImpl(); }
-			else { this->processImpl(pluginIn, pluginOut); }
+			if constexpr (AudioPortT::provideProcessBuffers()) { this->processImpl(pluginIn, pluginOut); }
+			else { this->processImpl(); }
 
 			// Write plugin output buffer to core
 			router.routeFromPlugin(pluginOut, bus);
@@ -247,47 +228,35 @@ protected:
 		 */
 	}
 
-	auto pinConnector() -> PluginPinConnector* { return &m_pinConnector; }
-
 private:
-	void updatePluginBuffers()
-	{
-		auto iface = this->bufferInterface();
-		if (!iface) { return; }
-		iface->updateBuffers(
-			m_pinConnector.in().channelCount(),
-			m_pinConnector.out().channelCount()
-		);
-	}
-
-	PluginPinConnector m_pinConnector;
+	AudioPortT m_audioPort;
 };
 
 //! Effect specialization
-template<typename SampleT, PluginConfig config>
-class AudioPlugin<Effect, SampleT, config>
+template<AudioPluginConfig config, class AudioPortT>
+class AudioPlugin<Effect, config, AudioPortT>
 	: public Effect
 	, public AudioProcessingMethod<Effect,
-		typename AudioDataTypeSelector<config.layout, SampleT, config.inputs>::type,
-		typename AudioDataTypeSelector<config.layout, const SampleT, config.outputs>::type,
-		config.inplace, config.customBuffer>
-	, public std::conditional_t<config.customBuffer,
-		AudioPluginBufferInterfaceProvider<config.layout, SampleT, config.inputs, config.outputs>,
-		AudioPluginBufferDefaultImpl<config.layout, SampleT, config.inputs, config.outputs, config.inplace>>
+		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, true>::type,
+		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, false>::type,
+		config.inplace, AudioPortT::provideProcessBuffers()>
 {
 public:
 	AudioPlugin(const Plugin::Descriptor* desc, Model* parent = nullptr,
 		const Plugin::Descriptor::SubPluginFeatures::Key* key = nullptr)
 		: Effect{desc, parent, key}
-		, m_pinConnector{config.inputs, config.outputs, false, this}
+		, m_audioPort{false, this}
 	{
-		connect(&m_pinConnector, &PluginPinConnector::pluginBuffersChanged,
-			this, &AudioPlugin::updatePluginBuffers);
 	}
 
-	auto pinConnector() const -> const PluginPinConnector* final { return &m_pinConnector; }
-
 protected:
+	auto audioPort() -> AudioPortT& { return m_audioPort; }
+
+	auto pinConnector() const -> const PluginPinConnector* final
+	{
+		return m_audioPort.pinConnector();
+	}
+
 	auto processAudioBufferImpl(CoreAudioDataMut inOut) -> bool final
 	{
 		if (isSleeping())
@@ -298,20 +267,21 @@ protected:
 
 		SampleFrame* temp = inOut.data();
 		const auto bus = CoreAudioBusMut{&temp, 1, inOut.size()};
-		auto bufferInterface = this->bufferInterface();
-		auto router = m_pinConnector.getRouter<config.layout, SampleT, config.inputs, config.outputs>();
+		auto buffers = m_audioPort.buffers();
+		assert(buffers != nullptr);
+		auto router = m_audioPort.getRouter();
 
 		ProcessStatus status;
 
 		if constexpr (config.inplace)
 		{
 			// Write core to plugin input buffer
-			const auto pluginInOut = bufferInterface->inputBuffer();
+			const auto pluginInOut = buffers->inputBuffer();
 			router.routeToPlugin(bus, pluginInOut);
 
 			// Process
-			if constexpr (config.customBuffer) { status = this->processImpl(); }
-			else { status = this->processImpl(pluginInOut); }
+			if constexpr (AudioPortT::provideProcessBuffers()) { status = this->processImpl(pluginInOut); }
+			else { status = this->processImpl(); }
 
 			// Write plugin output buffer to core
 			router.routeFromPlugin(pluginInOut, bus);
@@ -319,13 +289,13 @@ protected:
 		else
 		{
 			// Write core to plugin input buffer
-			const auto pluginIn = bufferInterface->inputBuffer();
-			const auto pluginOut = bufferInterface->outputBuffer();
+			const auto pluginIn = buffers->inputBuffer();
+			const auto pluginOut = buffers->outputBuffer();
 			router.routeToPlugin(bus, pluginIn);
 
 			// Process
-			if constexpr (config.customBuffer) { status = this->processImpl(); }
-			else { status = this->processImpl(pluginIn, pluginOut); }
+			if constexpr (AudioPortT::provideProcessBuffers()) { status = this->processImpl(pluginIn, pluginOut); }
+			else { status = this->processImpl(); }
 
 			// Write plugin output buffer to core
 			router.routeFromPlugin(pluginOut, bus);
@@ -363,20 +333,8 @@ protected:
 	{
 	}
 
-	auto pinConnector() -> PluginPinConnector* { return &m_pinConnector; }
-
 private:
-	void updatePluginBuffers()
-	{
-		auto iface = this->bufferInterface();
-		if (!iface) { return; }
-		iface->updateBuffers(
-			m_pinConnector.in().channelCount(),
-			m_pinConnector.out().channelCount()
-		);
-	}
-
-	PluginPinConnector m_pinConnector;
+	AudioPortT m_audioPort;
 };
 
 
@@ -399,30 +357,41 @@ private:
  * A `processImpl` interface method is provided which must be implemented by the plugin implementation.
  *
  * @param ParentT Either `Instrument` or `Effect`
- * @param SampleT The plugin's sample type - i.e. float, double, int32_t, `SampleFrame`, etc.
  * @param config Compile time configuration to customize `AudioPlugin`
+ * @param AudioPortT The audio port - must implement `PluginAudioPort`
  */
-template<class ParentT, typename SampleT, PluginConfig config>
+template<class ParentT, AudioPluginConfig config, class AudioPortT = DefaultPluginAudioPort<config>>
 class AudioPlugin
-	: public detail::AudioPlugin<ParentT, SampleT, config>
+	: public detail::AudioPlugin<ParentT, config, AudioPortT>
 {
-	static_assert(!std::is_const_v<SampleT>);
-	static_assert(!std::is_same_v<SampleT, SampleFrame>
+	static_assert(config.kind != AudioDataKind::SampleFrame
 		|| ((config.inputs == 0 || config.inputs == 2) && (config.outputs == 0 || config.outputs == 2)),
 		"Don't use SampleFrame if more than 2 processor channels are needed");
 
-	using Base = detail::AudioPlugin<ParentT, SampleT, config>;
+	static_assert(std::is_base_of_v<detail::PluginAudioPortTag, AudioPortT>,
+		"AudioPortT must be `PluginAudioPort` or inherit from it");
+
+	using Base = typename detail::AudioPlugin<ParentT, config, AudioPortT>;
 
 public:
-	using Base::AudioPlugin;
+	using Base::Base;
 };
 
-// NOTE: NotePlayHandle-based instruments are not supported yet
-using DefaultMidiInstrument = AudioPlugin<Instrument, SampleFrame,
-	PluginConfig{ .layout = AudioDataLayout::Interleaved, .inputs = 0, .outputs = 2, .inplace = true }>;
 
-using DefaultEffect = AudioPlugin<Effect, SampleFrame,
-	PluginConfig{ .layout = AudioDataLayout::Interleaved, .inputs = 2, .outputs = 2, .inplace = true }>;
+// NOTE: NotePlayHandle-based instruments are not supported yet
+using DefaultMidiInstrument = AudioPlugin<Instrument, AudioPluginConfig {
+	.kind = AudioDataKind::SampleFrame,
+	.layout = AudioDataLayout::Interleaved,
+	.inputs = 0,
+	.outputs = 2,
+	.inplace = true }>;
+
+using DefaultEffect = AudioPlugin<Effect, AudioPluginConfig {
+	.kind = AudioDataKind::SampleFrame,
+	.layout = AudioDataLayout::Interleaved,
+	.inputs = 2,
+	.outputs = 2,
+	.inplace = true }>;
 
 
 } // namespace lmms

--- a/include/AudioPlugin.h
+++ b/include/AudioPlugin.h
@@ -180,8 +180,6 @@ protected:
 
 	void playImpl(CoreAudioDataMut inOut) final
 	{
-		SampleFrame* temp = inOut.data();
-		const auto bus = CoreAudioBusMut{&temp, 1, inOut.size()};
 		auto buffers = m_audioPort.buffers();
 		if (!buffers)
 		{
@@ -189,6 +187,8 @@ protected:
 			return;
 		}
 
+		SampleFrame* temp = inOut.data();
+		const auto bus = CoreAudioBusMut{&temp, 1, inOut.size()};
 		auto router = m_audioPort.getRouter();
 
 		if constexpr (config.inplace)
@@ -275,10 +275,11 @@ protected:
 			return false;
 		}
 
-		SampleFrame* temp = inOut.data();
-		const auto bus = CoreAudioBusMut{&temp, 1, inOut.size()};
 		auto buffers = m_audioPort.buffers();
 		assert(buffers != nullptr);
+
+		SampleFrame* temp = inOut.data();
+		const auto bus = CoreAudioBusMut{&temp, 1, inOut.size()};
 		auto router = m_audioPort.getRouter();
 
 		ProcessStatus status;

--- a/include/AudioPlugin.h
+++ b/include/AudioPlugin.h
@@ -165,7 +165,7 @@ public:
 		: Instrument{desc, parent, key, flags}
 		, m_audioPort{true, this, std::forward<AudioPortArgsT>(audioPortArgs)...}
 	{
-		m_audioPort.updateBuffers(config.inputs, config.outputs, Engine::audioEngine()->framesPerPeriod());
+		m_audioPort.init();
 	}
 
 protected:
@@ -254,7 +254,7 @@ public:
 		: Effect{desc, parent, key}
 		, m_audioPort{false, this, std::forward<AudioPortArgsT>(audioPortArgs)...}
 	{
-		m_audioPort.updateBuffers(config.inputs, config.outputs, Engine::audioEngine()->framesPerPeriod());
+		m_audioPort.init();
 	}
 
 protected:

--- a/include/AudioPlugin.h
+++ b/include/AudioPlugin.h
@@ -152,8 +152,8 @@ template<AudioPluginConfig config, class AudioPortT>
 class AudioPlugin<Instrument, config, AudioPortT>
 	: public Instrument
 	, public AudioProcessingMethod<Instrument,
-		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, false>::type,
-		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, true>::type,
+		typename AudioDataViewSelector<config.kind, config.interleaved, config.inputs, false>::type,
+		typename AudioDataViewSelector<config.kind, config.interleaved, config.inputs, true>::type,
 		config.inplace, AudioPortT::provideProcessBuffers()>
 {
 public:
@@ -242,8 +242,8 @@ template<AudioPluginConfig config, class AudioPortT>
 class AudioPlugin<Effect, config, AudioPortT>
 	: public Effect
 	, public AudioProcessingMethod<Effect,
-		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, false>::type,
-		typename AudioDataViewSelector<config.kind, config.layout, config.inputs, true>::type,
+		typename AudioDataViewSelector<config.kind, config.interleaved, config.inputs, false>::type,
+		typename AudioDataViewSelector<config.kind, config.interleaved, config.inputs, true>::type,
 		config.inplace, AudioPortT::provideProcessBuffers()>
 {
 public:
@@ -360,8 +360,8 @@ private:
  * interfaces with LMMS Core.
  *
  * This design allows for some compile-time customization over aspects of the plugin implementation
- * such as the number of in/out channels and the audio data layout, so plugin developers can
- * implement their plugin in whatever way works best for them. All the mapping from their plugin to/from
+ * such as the number of in/out channels and whether samples are interleaved, so plugin developers can
+ * implement their plugin in whatever way works best for them. All the mapping of their plugin to/from
  * LMMS Core is handled here, at compile-time where possible for best performance.
  *
  * A `processImpl` interface method is provided which must be implemented by the plugin implementation.
@@ -394,14 +394,14 @@ public:
 // NOTE: NotePlayHandle-based instruments are not supported yet
 using DefaultMidiInstrument = AudioPlugin<Instrument, AudioPluginConfig {
 	.kind = AudioDataKind::SampleFrame,
-	.layout = AudioDataLayout::Interleaved,
+	.interleaved = true,
 	.inputs = 0,
 	.outputs = 2,
 	.inplace = true }>;
 
 using DefaultEffect = AudioPlugin<Effect, AudioPluginConfig {
 	.kind = AudioDataKind::SampleFrame,
-	.layout = AudioDataLayout::Interleaved,
+	.interleaved = true,
 	.inputs = 2,
 	.outputs = 2,
 	.inplace = true }>;

--- a/include/AudioPluginBuffer.h
+++ b/include/AudioPluginBuffer.h
@@ -25,7 +25,6 @@
 #ifndef LMMS_AUDIO_PLUGIN_BUFFER_H
 #define LMMS_AUDIO_PLUGIN_BUFFER_H
 
-#include <QObject>
 #include <type_traits>
 #include <vector>
 
@@ -315,17 +314,7 @@ using AudioPluginBufferInterface = detail::AudioPluginBufferInterface<config>;
 
 //! Default implementation of `AudioPluginBufferInterface`
 template<AudioPluginConfig config>
-using AudioPluginBufferDefaultImpl = detail::AudioPluginBufferDefaultImpl<config>;
-
-
-/**
- * Buffer to be implemented by the plugin implementation.
- * Use in an audio port's template parameter.
- */
-template<AudioPluginConfig config>
-class AudioPluginBufferCustom : public AudioPluginBufferInterface<config>
-{
-};
+using DefaultAudioPluginBuffer = detail::AudioPluginBufferDefaultImpl<config>;
 
 
 } // namespace lmms

--- a/include/AudioPluginBuffer.h
+++ b/include/AudioPluginBuffer.h
@@ -127,8 +127,8 @@ class AudioPluginBufferDefaultImpl<config, kind, false, false>
 	// Optimization to avoid need for std::vector if size is known at compile time
 	using AccessBufferType = std::conditional_t<
 		s_hasStaticChannelCount,
-		std::array<SplitSampleType<SampleT>*, static_cast<std::size_t>(config.inputs + config.outputs)>,
-		std::vector<SplitSampleType<SampleT>*>>;
+		std::array<SampleT*, static_cast<std::size_t>(config.inputs + config.outputs)>,
+		std::vector<SampleT*>>;
 
 public:
 	AudioPluginBufferDefaultImpl() = default;
@@ -175,7 +175,7 @@ public:
 
 		m_frames = frames;
 
-		SplitSampleType<SampleT>* ptr = m_sourceBuffer.data();
+		SampleT* ptr = m_sourceBuffer.data();
 		for (std::size_t channel = 0; channel < channels; ++channel)
 		{
 			m_accessBuffer[channel] = ptr;
@@ -188,7 +188,7 @@ public:
 
 private:
 	//! All input buffers followed by all output buffers
-	std::vector<SplitSampleType<SampleT>> m_sourceBuffer;
+	std::vector<SampleT> m_sourceBuffer;
 
 	//! Provides [channel][frame] view into `m_sourceBuffer`
 	AccessBufferType m_accessBuffer;
@@ -216,8 +216,8 @@ class AudioPluginBufferDefaultImpl<config, kind, false, true>
 	// Optimization to avoid need for std::vector if size is known at compile time
 	using AccessBufferType = std::conditional_t<
 		s_hasStaticChannelCount,
-		std::array<SplitSampleType<SampleT>*, static_cast<std::size_t>(config.outputs)>,
-		std::vector<SplitSampleType<SampleT>*>>;
+		std::array<SampleT*, static_cast<std::size_t>(config.outputs)>,
+		std::vector<SampleT*>>;
 
 public:
 	AudioPluginBufferDefaultImpl() = default;
@@ -256,7 +256,7 @@ public:
 
 		m_frames = frames;
 
-		SplitSampleType<SampleT>* ptr = m_sourceBuffer.data();
+		SampleT* ptr = m_sourceBuffer.data();
 		for (std::size_t channel = 0; channel < channels; ++channel)
 		{
 			m_accessBuffer[channel] = ptr;
@@ -268,7 +268,7 @@ public:
 
 private:
 	//! All input buffers followed by all output buffers
-	std::vector<SplitSampleType<SampleT>> m_sourceBuffer;
+	std::vector<SampleT> m_sourceBuffer;
 
 	//! Provides [channel][frame] view into `m_sourceBuffer`
 	AccessBufferType m_accessBuffer;

--- a/include/AudioPluginBuffer.h
+++ b/include/AudioPluginBuffer.h
@@ -29,9 +29,7 @@
 #include <vector>
 
 #include "AudioData.h"
-#include "AudioEngine.h"
 #include "AudioPluginConfig.h"
-#include "Engine.h"
 #include "SampleFrame.h"
 #include "lmms_basics.h"
 

--- a/include/AudioPluginBuffer.h
+++ b/include/AudioPluginBuffer.h
@@ -179,7 +179,7 @@ public:
 		SplitSampleType<SampleT>* ptr = m_sourceBuffer.data();
 		for (std::size_t channel = 0; channel < channels; ++channel)
 		{
-			m_accessBuffer[idx] = ptr;
+			m_accessBuffer[channel] = ptr;
 			ptr += frames;
 		}
 
@@ -260,7 +260,7 @@ public:
 		SplitSampleType<SampleT>* ptr = m_sourceBuffer.data();
 		for (std::size_t channel = 0; channel < channels; ++channel)
 		{
-			m_accessBuffer[idx] = ptr;
+			m_accessBuffer[channel] = ptr;
 			ptr += frames;
 		}
 

--- a/include/AudioPluginConfig.h
+++ b/include/AudioPluginConfig.h
@@ -35,8 +35,8 @@ struct AudioPluginConfig
 	//! The audio data type used by the plugin
 	AudioDataKind kind;
 
-	//! The audio data layout used by the plugin
-	AudioDataLayout layout;
+	//! The audio data layout used by the plugin: interleaved or non-interleaved
+	bool interleaved;
 
 	//! The number of plugin input channels, or `DynamicChannelCount` if unknown at compile time
 	int inputs = DynamicChannelCount;

--- a/include/AudioPluginConfig.h
+++ b/include/AudioPluginConfig.h
@@ -1,0 +1,53 @@
+/*
+ * AudioPluginConfig.h - Audio plugin configuration
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_AUDIO_PLUGIN_CONFIG_H
+#define LMMS_AUDIO_PLUGIN_CONFIG_H
+
+#include "AudioData.h"
+
+namespace lmms {
+
+//! Compile time customizations for an audio plugin
+struct AudioPluginConfig
+{
+	//! The audio data type used by the plugin
+	AudioDataKind kind;
+
+	//! The audio data layout used by the plugin
+	AudioDataLayout layout;
+
+	//! The number of plugin input channels, or `DynamicChannelCount` if unknown at compile time
+	int inputs = DynamicChannelCount;
+
+	//! The number of plugin output channels, or `DynamicChannelCount` if unknown at compile time
+	int outputs = DynamicChannelCount;
+
+	//! In-place processing - true (always in-place) or false (dynamic, customizable in audio buffer impl)
+	bool inplace = false;
+};
+
+} // namespace lmms
+
+#endif // LMMS_AUDIO_PLUGIN_CONFIG_H

--- a/include/PluginAudioPort.h
+++ b/include/PluginAudioPort.h
@@ -49,7 +49,7 @@ class PluginAudioPort
 {
 public:
 	PluginAudioPort(bool isInstrument, Model* parent)
-		: PluginPinConnector{isInstrument, parent}
+		: PluginPinConnector{config.inputs, config.outputs, isInstrument, parent}
 	{
 	}
 

--- a/include/PluginAudioPort.h
+++ b/include/PluginAudioPort.h
@@ -130,7 +130,7 @@ public:
 
 	auto buffers() -> BufferT<config>* final { return static_cast<BufferT<config>*>(this); }
 
-protected:
+private:
 	void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) final
 	{
 		// Connects the pin connector to the buffers
@@ -155,8 +155,8 @@ public:
 
 	constexpr static auto provideProcessBuffers() -> bool { return false; }
 
-protected:
-	void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) override
+private:
+	void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) final
 	{
 		// Connects the pin connector to the buffers
 		this->updateBuffers(inChannels, outChannels, frames);

--- a/include/PluginAudioPort.h
+++ b/include/PluginAudioPort.h
@@ -1,0 +1,152 @@
+/*
+ * PluginAudioPort.h
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_PLUGIN_AUDIO_PORT_H
+#define LMMS_PLUGIN_AUDIO_PORT_H
+
+#include "AudioPluginBuffer.h"
+#include "AudioPluginConfig.h"
+#include "PluginPinConnector.h"
+
+namespace lmms
+{
+
+
+namespace detail {
+struct PluginAudioPortTag {};
+} // namespace detail
+
+
+/**
+ * Interface for an audio port implementation.
+ * Contains a pin connector and provides access to the audio buffers.
+ */
+template<AudioPluginConfig config>
+class PluginAudioPort
+	: public PluginPinConnector // TODO: private inheritance?
+	, public detail::PluginAudioPortTag
+{
+public:
+	auto pinConnector() const -> const PluginPinConnector&
+	{
+		return *static_cast<const PluginPinConnector*>(this);
+	}
+
+	/**
+	 * Returns false if the plugin is not loaded.
+	 * Custom audio ports with a "plugin not loaded" state should override this.
+	 */
+	virtual auto active() const -> bool { return true; }
+
+	/**
+	 * `AudioPlugin` calls this to decide whether to pass the audio buffers to
+	 * the `processImpl` methods.
+	 *
+	 * Sending the audio buffers to `processImpl` in the plugin implementation may be
+	 * pointless for custom audio port implementations that manage their own buffers,
+	 * so in that case reimplementing this method in a child class to return `false`
+	 * results in a cleaner interface.
+	 */
+	constexpr static auto provideProcessBuffers() -> bool { return true; }
+
+protected:
+	PluginAudioPort(bool isInstrument, Model* parent)
+		: PluginPinConnector{isInstrument, parent}
+	{
+	}
+
+	auto pinConnector() -> PluginPinConnector& { return *static_cast<PluginPinConnector*>(this); }
+
+	//! Returns the pin connector's router
+	auto getRouter() const -> PluginPinConnector::Router<config>
+	{
+		return pinConnector().template getRouter<config>();
+	}
+
+	//! Returns nullptr if the port is unavailable (i.e. Vestige with no plugin loaded)
+	virtual auto buffers() -> AudioPluginBufferInterface<config>* = 0;
+};
+
+
+/**
+ * The default audio port for plugins that do not provide their own.
+ * Contains a pin connector and audio buffers.
+ *
+ * This audio port still has *some* ability for customization by using a custom `BufferT`,
+ * but for full control, you'll need to provide your own audio port implementation.
+ */
+template<AudioPluginConfig config, template<AudioPluginConfig> class BufferT>
+class PluginAudioPortDefaultImpl
+	: public PluginAudioPort<config>
+	, public BufferT<config>
+{
+	static_assert(std::is_base_of_v<AudioPluginBufferInterface<config>, BufferT<config>>,
+		"BufferT must derive from AudioPluginBufferInterface");
+
+protected:
+	using PluginAudioPort<config>::PluginAudioPort;
+
+	auto buffers() -> BufferT<config>* final { return static_cast<BufferT<config>*>(this); }
+
+	static constexpr auto pluginConfig() -> AudioPluginConfig { return config; }
+
+private:
+	void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) final
+	{
+		// Connects the pin connector to the buffers
+		this->updateBuffers(inChannels, outChannels, frames);
+	}
+};
+
+
+//! Default audio port
+template<AudioPluginConfig config>
+using DefaultPluginAudioPort = PluginAudioPortDefaultImpl<config, AudioPluginBufferDefaultImpl>;
+
+
+//! Custom audio port - audio buffer interface to be implementated in child class
+template<AudioPluginConfig config>
+class PluginAudioPortCustom
+	: public PluginAudioPort<config>
+	, public AudioPluginBufferInterface<config>
+{
+public:
+	constexpr static auto provideProcessBuffers() -> bool { return false; }
+
+protected:
+	using PluginAudioPort<config>::PluginAudioPort;
+
+	void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) override
+	{
+		// Connects the pin connector to the buffers
+		this->updateBuffers(inChannels, outChannels, frames);
+	}
+
+	static constexpr auto pluginConfig() -> AudioPluginConfig { return config; }
+};
+
+
+} // namespace lmms
+
+#endif // LMMS_PLUGIN_AUDIO_PORT_H

--- a/include/PluginAudioPort.h
+++ b/include/PluginAudioPort.h
@@ -25,8 +25,10 @@
 #ifndef LMMS_PLUGIN_AUDIO_PORT_H
 #define LMMS_PLUGIN_AUDIO_PORT_H
 
+#include "AudioEngine.h"
 #include "AudioPluginBuffer.h"
 #include "AudioPluginConfig.h"
+#include "Engine.h"
 #include "PluginPinConnector.h"
 
 namespace lmms
@@ -51,6 +53,21 @@ public:
 	PluginAudioPort(bool isInstrument, Model* parent)
 		: PluginPinConnector{config.inputs, config.outputs, isInstrument, parent}
 	{
+	}
+
+	/**
+	 * Must be called after constructing an audio port.
+	 *
+	 * NOTE: This cannot be called in the constructor due
+	 *       to the use of a virtual method.
+	 */
+	void init()
+	{
+		if (auto buffers = this->buffers())
+		{
+			buffers->updateBuffers(in().channelCount(), out().channelCount(),
+				Engine::audioEngine()->framesPerPeriod());
+		}
 	}
 
 	auto pinConnector() const -> const PluginPinConnector&

--- a/include/PluginPinConnector.h
+++ b/include/PluginPinConnector.h
@@ -2,7 +2,7 @@
  * PluginPinConnector.h - Specifies how to route audio channels
  *                        in and out of a plugin.
  *
- * Copyright (c) 2024 Dalton Messmer <messmer.dalton/at/gmail.com>
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "AudioData.h"
+#include "AudioPluginConfig.h"
 #include "AutomatableModel.h"
 #include "SampleFrame.h"
 #include "SerializingObject.h"
@@ -198,33 +199,35 @@ public:
 	 *     `inOut`   : track channels from/to LMMS core
 	 *                 `inOut.frames` provides the number of frames in each `in`/`inOut` audio buffer
 	 */
-	template<AudioDataLayout layout, typename SampleT, int channelCountIn, int channelCountOut>
-	class Router;
-
-	//! Non-`SampleFrame` routing
-	template<AudioDataLayout layout, typename SampleT, int channelCountIn, int channelCountOut>
+	template<AudioPluginConfig config, AudioDataKind kind = config.kind, AudioDataLayout layout = config.layout>
 	class Router
 	{
+		static_assert(always_false_v<Router<config, kind, layout>>,
+			"A router for the requested configuration is not implemented yet");
+	};
+
+	//! Non-`SampleFrame` routing
+	template<AudioPluginConfig config, AudioDataKind kind>
+	class Router<config, kind, AudioDataLayout::Split>
+	{
+		using SampleT = GetAudioDataType<kind>;
+
 	public:
-		static_assert(layout == AudioDataLayout::Split, "Only split data is implemented so far");
+		explicit Router(PluginPinConnector& parent) : m_pc{&parent} {}
 
-		Router(PluginPinConnector& parent) : m_pc{&parent} {}
-
-		void routeToPlugin(CoreAudioBus in, SplitAudioData<SampleT, channelCountIn> out) const;
-		void routeFromPlugin(SplitAudioData<const SampleT, channelCountOut> in, CoreAudioBusMut inOut) const;
+		void routeToPlugin(CoreAudioBus in, SplitAudioData<GetAudioDataType<kind>, config.inputs> out) const;
+		void routeFromPlugin(SplitAudioData<const GetAudioDataType<kind>, config.outputs> in, CoreAudioBusMut inOut) const;
 
 	private:
 		PluginPinConnector* m_pc;
 	};
 
 	//! `SampleFrame` routing
-	template<AudioDataLayout layout, int channelCountIn, int channelCountOut>
-	class Router<layout, SampleFrame, channelCountIn, channelCountOut>
+	template<AudioPluginConfig config>
+	class Router<config, AudioDataKind::SampleFrame, AudioDataLayout::Interleaved>
 	{
 	public:
-		static_assert(layout == AudioDataLayout::Interleaved);
-
-		Router(PluginPinConnector& parent) : m_pc{&parent} {}
+		explicit Router(PluginPinConnector& parent) : m_pc{&parent} {}
 
 		void routeToPlugin(CoreAudioBus in, CoreAudioDataMut out) const;
 		void routeFromPlugin(CoreAudioData in, CoreAudioBusMut inOut) const;
@@ -234,10 +237,10 @@ public:
 	};
 
 
-	template<AudioDataLayout layout, typename SampleT, int channelCountIn, int channelCountOut>
-	auto getRouter() -> Router<layout, SampleT, channelCountIn, channelCountOut>
+	template<AudioPluginConfig config>
+	auto getRouter() -> Router<config>
 	{
-		return Router<layout, SampleT, channelCountIn, channelCountOut>{*this};
+		return Router<config>{*this};
 	}
 
 
@@ -248,7 +251,8 @@ public:
 	void loadSettings(const QDomElement& elem) override;
 	auto nodeName() const -> QString override { return "pins"; }
 
-	auto instantiateView(QWidget* parent) const -> gui::PluginPinConnectorView*;
+	virtual auto instantiateView(QWidget* parent) const -> gui::PluginPinConnectorView*;
+
 	auto getChannelCountText() const -> QString;
 
 	static constexpr std::size_t MaxTrackChannels = 256; // TODO: Move somewhere else
@@ -261,12 +265,22 @@ signals:
 	//! Called when the plugin channel counts change or the track channel counts change
 	//void propertiesChanged(); [from Model base class]
 
-	//! Called when the plugin channel counts change or if the sample rate changes
-	void pluginBuffersChanged();
-
 public slots:
 	void setTrackChannelCount(int count);
 	void updateRoutedChannels(unsigned int trackChannel);
+
+protected:
+	/**
+	 * To be implemented by the plugin's audio port.
+	 * Called when channel counts or sample rate changes.
+	 *
+	 * NOTE: If this method is called in the pin connector's constructor,
+	 *       it will not call the implementation in a derived class
+	 *       since that class has not been constructed yet. During construction,
+	 *       buffer implementations should initialize themselves rather than
+	 *       rely on this method.
+	 */
+	virtual void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) {}
 
 private:
 	void updateAllRoutedChannels();
@@ -300,11 +314,11 @@ private:
 
 // Non-`SampleFrame` Router out-of-class definitions
 
-template<AudioDataLayout layout, typename SampleT, int channelCountIn, int channelCountOut>
-inline void PluginPinConnector::Router<layout, SampleT, channelCountIn, channelCountOut>::routeToPlugin(
-	CoreAudioBus in, SplitAudioData<SampleT, channelCountIn> out) const
+template<AudioPluginConfig config, AudioDataKind kind>
+inline void PluginPinConnector::Router<config, kind, AudioDataLayout::Split>::routeToPlugin(
+	CoreAudioBus in, SplitAudioData<SampleT, config.inputs> out) const
 {
-	if constexpr (channelCountIn == 0) { return; }
+	if constexpr (config.inputs == 0) { return; }
 
 	assert(m_pc->m_in.channelCount() != DynamicChannelCount);
 	if (m_pc->m_in.channelCount() == 0) { return; }
@@ -320,7 +334,7 @@ inline void PluginPinConnector::Router<layout, SampleT, channelCountIn, channelC
 
 	for (std::uint32_t outChannel = 0; outChannel < out.channels(); ++outChannel)
 	{
-		SampleType<layout, SampleT>* outPtr = out.buffer(outChannel);
+		SampleType<config.layout, SampleT>* outPtr = out.buffer(outChannel);
 
 		for (std::uint8_t inChannelPairIdx = 0; inChannelPairIdx < inSizeConstrained; ++inChannelPairIdx)
 		{
@@ -366,11 +380,11 @@ inline void PluginPinConnector::Router<layout, SampleT, channelCountIn, channelC
 	}
 }
 
-template<AudioDataLayout layout, typename SampleT, int channelCountIn, int channelCountOut>
-inline void PluginPinConnector::Router<layout, SampleT, channelCountIn, channelCountOut>::routeFromPlugin(
-	SplitAudioData<const SampleT, channelCountOut> in, CoreAudioBusMut inOut) const
+template<AudioPluginConfig config, AudioDataKind kind>
+inline void PluginPinConnector::Router<config, kind, AudioDataLayout::Split>::routeFromPlugin(
+	SplitAudioData<const SampleT, config.outputs> in, CoreAudioBusMut inOut) const
 {
-	if constexpr (channelCountOut == 0) { return; }
+	if constexpr (config.outputs == 0) { return; }
 
 	assert(m_pc->m_out.channelCount() != DynamicChannelCount);
 	if (m_pc->m_out.channelCount() == 0) { return; }
@@ -420,7 +434,7 @@ inline void PluginPinConnector::Router<layout, SampleT, channelCountIn, channelC
 
 		for (pi_ch_t inChannel = 0; inChannel < in.channels(); ++inChannel)
 		{
-			const SampleType<layout, const SampleT>* inPtr = in.buffer(inChannel);
+			const SampleType<config.layout, const SampleT>* inPtr = in.buffer(inChannel);
 
 			if constexpr (rc == 0b11)
 			{
@@ -507,11 +521,12 @@ inline void PluginPinConnector::Router<layout, SampleT, channelCountIn, channelC
 
 // `SampleFrame` Router out-of-class definitions
 
-template<AudioDataLayout layout, int channelCountIn, int channelCountOut>
-inline void PluginPinConnector::Router<layout, SampleFrame, channelCountIn, channelCountOut>::routeToPlugin(
+template<AudioPluginConfig config>
+inline void PluginPinConnector::Router<config,
+	AudioDataKind::SampleFrame, AudioDataLayout::Interleaved>::routeToPlugin(
 	CoreAudioBus in, CoreAudioDataMut out) const
 {
-	if constexpr (channelCountIn == 0) { return; }
+	if constexpr (config.inputs == 0) { return; }
 
 	assert(m_pc->m_in.channelCount() != DynamicChannelCount);
 	if (m_pc->m_in.channelCount() == 0) { return; }
@@ -598,11 +613,12 @@ inline void PluginPinConnector::Router<layout, SampleFrame, channelCountIn, chan
 	}
 }
 
-template<AudioDataLayout layout, int channelCountIn, int channelCountOut>
-inline void PluginPinConnector::Router<layout, SampleFrame, channelCountIn, channelCountOut>::routeFromPlugin(
+template<AudioPluginConfig config>
+inline void PluginPinConnector::Router<config,
+	AudioDataKind::SampleFrame, AudioDataLayout::Interleaved>::routeFromPlugin(
 	CoreAudioData in, CoreAudioBusMut inOut) const
 {
-	if constexpr (channelCountOut == 0) { return; }
+	if constexpr (config.outputs == 0) { return; }
 
 	assert(m_pc->m_out.channelCount() != DynamicChannelCount);
 	if (m_pc->m_out.channelCount() == 0) { return; }

--- a/include/PluginPinConnector.h
+++ b/include/PluginPinConnector.h
@@ -331,7 +331,7 @@ inline void PluginPinConnector::Router<config, kind, AudioDataLayout::Split>::ro
 	// Zero the output buffer - TODO: std::memcpy?
 	{
 		auto source = out.sourceBuffer();
-		std::fill_n(source.data(), out.size(), SampleT{});
+		std::fill_n(source.data(), source.size(), SampleT{});
 		//std::memset(source.data(), 0, source.size_bytes());
 	}
 

--- a/include/PluginPinConnector.h
+++ b/include/PluginPinConnector.h
@@ -274,11 +274,7 @@ protected:
 	 * To be implemented by the plugin's audio port.
 	 * Called when channel counts or sample rate changes.
 	 *
-	 * NOTE: If this method is called in the pin connector's constructor,
-	 *       it will not call the implementation in a derived class
-	 *       since that class has not been constructed yet. During construction,
-	 *       buffer implementations should initialize themselves rather than
-	 *       rely on this method.
+	 * NOTE: Virtual method, do not call in constructor.
 	 */
 	virtual void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) {}
 

--- a/include/PluginPinConnector.h
+++ b/include/PluginPinConnector.h
@@ -213,13 +213,13 @@ public:
 		using SampleT = GetAudioDataType<kind>;
 
 	public:
-		explicit Router(PluginPinConnector& parent) : m_pc{&parent} {}
+		explicit Router(const PluginPinConnector& parent) : m_pc{&parent} {}
 
 		void routeToPlugin(CoreAudioBus in, SplitAudioData<GetAudioDataType<kind>, config.inputs> out) const;
 		void routeFromPlugin(SplitAudioData<const GetAudioDataType<kind>, config.outputs> in, CoreAudioBusMut inOut) const;
 
 	private:
-		PluginPinConnector* m_pc;
+		const PluginPinConnector* m_pc;
 	};
 
 	//! `SampleFrame` routing
@@ -227,18 +227,18 @@ public:
 	class Router<config, AudioDataKind::SampleFrame, AudioDataLayout::Interleaved>
 	{
 	public:
-		explicit Router(PluginPinConnector& parent) : m_pc{&parent} {}
+		explicit Router(const PluginPinConnector& parent) : m_pc{&parent} {}
 
 		void routeToPlugin(CoreAudioBus in, CoreAudioDataMut out) const;
 		void routeFromPlugin(CoreAudioData in, CoreAudioBusMut inOut) const;
 
 	private:
-		PluginPinConnector* m_pc;
+		const PluginPinConnector* m_pc;
 	};
 
 
 	template<AudioPluginConfig config>
-	auto getRouter() -> Router<config>
+	auto getRouter() const -> Router<config>
 	{
 		return Router<config>{*this};
 	}

--- a/include/PluginPinConnector.h
+++ b/include/PluginPinConnector.h
@@ -331,6 +331,7 @@ inline void PluginPinConnector::Router<config, kind, false>::routeToPlugin(
 	// Zero the output buffer - TODO: std::memcpy?
 	{
 		auto source = out.sourceBuffer();
+		assert(source.data() != nullptr);
 		std::fill_n(source.data(), source.size(), SampleT{});
 		//std::memset(source.data(), 0, source.size_bytes());
 	}

--- a/include/PluginPinConnector.h
+++ b/include/PluginPinConnector.h
@@ -337,7 +337,7 @@ inline void PluginPinConnector::Router<config, kind, false>::routeToPlugin(
 
 	for (std::uint32_t outChannel = 0; outChannel < out.channels(); ++outChannel)
 	{
-		SampleType<config.interleaved, SampleT>* outPtr = out.buffer(outChannel);
+		SampleT* outPtr = out.buffer(outChannel);
 
 		for (std::uint8_t inChannelPairIdx = 0; inChannelPairIdx < inSizeConstrained; ++inChannelPairIdx)
 		{
@@ -436,7 +436,7 @@ inline void PluginPinConnector::Router<config, kind, false>::routeFromPlugin(
 
 		for (pi_ch_t inChannel = 0; inChannel < in.channels(); ++inChannel)
 		{
-			const SampleType<config.interleaved, const SampleT>* inPtr = in.buffer(inChannel);
+			const SampleT* inPtr = in.buffer(inChannel);
 
 			if constexpr (rc == 0b11)
 			{

--- a/include/PluginPinConnectorView.h
+++ b/include/PluginPinConnectorView.h
@@ -1,7 +1,7 @@
 /*
  * PluginPinConnectorView.h - Displays pin connectors
  *
- * Copyright (c) 2024 Dalton Messmer <messmer.dalton/at/gmail.com>
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -76,7 +76,7 @@ class LMMS_EXPORT RemotePlugin : public QObject, public RemotePluginBase
 {
 	Q_OBJECT
 public:
-	explicit RemotePlugin(RemotePluginAudioPortController& controller, Model* parent = nullptr);
+	explicit RemotePlugin(RemotePluginAudioPortController& audioPort);
 	~RemotePlugin() override;
 
 	inline bool isRunning()
@@ -149,9 +149,9 @@ public:
 		m_commMutex.unlock();
 	}
 
-	auto audioPortController() -> RemotePluginAudioPortController*
+	auto audioPort() -> RemotePluginAudioPortController*
 	{
-		return m_audioPortController;
+		return m_audioPort;
 	}
 
 	//auto frames() const -> f_cnt_t { return m_frames; }
@@ -181,7 +181,7 @@ private:
 	QMutex m_commMutex;
 #endif
 
-	RemotePluginAudioPortController* const m_audioPortController = nullptr;
+	RemotePluginAudioPortController* const m_audioPort = nullptr;
 
 	SharedMemory<float[]> m_audioBuffer; // NOLINT
 	std::size_t m_audioBufferSize = 0; // TODO: Move to `SharedMemory`?

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -25,9 +25,6 @@
 #ifndef LMMS_REMOTE_PLUGIN_H
 #define LMMS_REMOTE_PLUGIN_H
 
-#include <QObject>
-#include <cassert>
-
 #include "AudioData.h"
 #include "RemotePluginBase.h"
 #include "SharedMemory.h"
@@ -40,7 +37,6 @@
 namespace lmms
 {
 
-class Model;
 class RemotePlugin;
 class RemotePluginAudioPortController;
 class SampleFrame;
@@ -153,10 +149,6 @@ public:
 	{
 		return m_audioPort;
 	}
-
-	//auto frames() const -> f_cnt_t { return m_frames; }
-	//auto channelsIn() const -> pi_ch_t { return m_channelsIn; }
-	//auto channelsOut() const -> pi_ch_t { return m_channelsOut; }
 
 	auto inputBuffer() const -> Span<float> { return m_inputBuffer; }
 	auto outputBuffer() const -> Span<float> { return m_outputBuffer; }

--- a/include/RemotePluginAudioPort.h
+++ b/include/RemotePluginAudioPort.h
@@ -185,8 +185,8 @@ private:
 	auto remoteActive() const -> bool { return m_buffers != nullptr && m_active; }
 
 	// Views into RemotePlugin's shared memory buffer
-	std::vector<SplitSampleType<float>*> m_audioBufferIn;
-	std::vector<SplitSampleType<float>*> m_audioBufferOut;
+	std::vector<float*> m_audioBufferIn;
+	std::vector<float*> m_audioBufferOut;
 
 	bool m_active = false;
 };

--- a/include/RemotePluginAudioPort.h
+++ b/include/RemotePluginAudioPort.h
@@ -51,13 +51,13 @@ class LMMS_EXPORT RemotePluginAudioPortController
 public:
 	RemotePluginAudioPortController(PluginPinConnector& pinConnector);
 
-	//! Connects `RemotePlugin`'s buffers to audio port; Call after buffers are created
+	//! Connects RemotePlugin's buffers to audio port; Call after buffers are created
 	void connectBuffers(RemotePlugin* buffers)
 	{
 		m_buffers = buffers;
 	}
 
-	//! Disconnects `RemotePlugin`'s buffers from audio port; Call before buffers are destroyed
+	//! Disconnects RemotePlugin's buffers from audio port; Call before buffers are destroyed
 	void disconnectBuffers()
 	{
 		m_buffers = nullptr;

--- a/include/RemotePluginAudioPort.h
+++ b/include/RemotePluginAudioPort.h
@@ -27,6 +27,7 @@
 
 #include "PluginAudioPort.h"
 #include "lmms_basics.h"
+#include "lmms_export.h"
 
 namespace lmms
 {
@@ -45,7 +46,7 @@ class RemotePlugin;
  *       weird regression.
  */
 
-class RemotePluginAudioPortController
+class LMMS_EXPORT RemotePluginAudioPortController
 {
 public:
 	RemotePluginAudioPortController(PluginPinConnector& pinConnector);

--- a/include/RemotePluginAudioPort.h
+++ b/include/RemotePluginAudioPort.h
@@ -1,0 +1,169 @@
+/*
+ * RemotePluginAudioPort.h - PluginAudioPort implementation for RemotePlugin
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_REMOTE_PLUGIN_AUDIO_PORT_H
+#define LMMS_REMOTE_PLUGIN_AUDIO_PORT_H
+
+#include "PluginAudioPort.h"
+#include "lmms_basics.h"
+
+namespace lmms
+{
+
+class RemotePlugin;
+
+class RemotePluginAudioPortController
+{
+public:
+	RemotePluginAudioPortController(PluginPinConnector& pinConnector);
+
+	//! Call after a RemotePlugin is created
+	void activate(RemotePlugin* remotePlugin)
+	{
+		m_remotePlugin = remotePlugin;
+		remotePluginUpdateBuffers(
+			m_pinConnector->in().channelCount(),
+			m_pinConnector->out().channelCount(),
+			m_frames);
+	}
+
+	//! Call before a RemotePlugin is destroyed
+	void deactivate()
+	{
+		m_remotePlugin = nullptr;
+	}
+
+	auto pinConnector() -> PluginPinConnector&
+	{
+		return *m_pinConnector;
+	}
+
+protected:
+	void remotePluginUpdateBuffers(int channelsIn, int channelsOut, fpp_t frames);
+	auto remotePluginInputBuffer() const -> float*;
+	auto remotePluginOutputBuffer() const -> float*;
+
+	RemotePlugin* m_remotePlugin = nullptr;
+	PluginPinConnector* m_pinConnector = nullptr;
+
+	fpp_t m_frames = 0;
+};
+
+
+//! `PluginAudioPort` implementation for `RemotePlugin`
+template<AudioPluginConfig config>
+class RemotePluginAudioPort
+	: public PluginAudioPortCustom<config>
+	, public RemotePluginAudioPortController
+{
+	using SampleT = GetAudioDataType<config.kind>;
+
+public:
+	using PluginAudioPortCustom<config>::PluginAudioPortCustom;
+
+	static_assert(config.kind == AudioDataKind::F32, "RemotePlugin only supports float");
+	static_assert(config.layout == AudioDataLayout::Split, "RemotePlugin only supports non-interleaved");
+	static_assert(!config.inplace, "RemotePlugin does not support inplace processing");
+
+	auto controller() -> RemotePluginAudioPortController&
+	{
+		return *static_cast<RemotePluginAudioPortController*>(this);
+	}
+
+	/*
+	 * `PluginAudioPort` implementation
+	 */
+
+	//! Only returns the buffer interface if audio port is active
+	auto buffers() -> AudioPluginBufferInterface<config>* final
+	{
+		return active() ? this : nullptr;
+	}
+
+	/*
+	 * `AudioPluginBufferInterface` implementation
+	 */
+
+	auto inputBuffer() -> SplitAudioData<SampleT, config.inputs> override
+	{
+		assert(m_remotePlugin != nullptr);
+		return {m_audioBufferIn.data(), this->in().channelCount(), m_frames};
+	}
+
+	auto outputBuffer() -> SplitAudioData<SampleT, config.outputs> override
+	{
+		assert(m_remotePlugin != nullptr);
+		return {m_audioBufferOut.data(), this->out().channelCount(), m_frames};
+	}
+
+	void updateBuffers(int channelsIn, int channelsOut, f_cnt_t frames) override
+	{
+		if (!m_remotePlugin) { return; }
+		remotePluginUpdateBuffers(channelsIn, channelsOut, frames);
+	}
+
+	/*
+	 * `PluginPinConnector` implementation
+	 */
+
+	//! Receives updates from the pin connector
+	void bufferPropertiesChanged(int inChannels, int outChannels, f_cnt_t frames) override
+	{
+		if (!m_remotePlugin) { return; }
+
+		m_frames = frames;
+
+		// Connects the pin connector to the buffers
+		updateBuffers(inChannels, outChannels, frames);
+
+		// Update the views into the RemotePlugin buffer
+		float* ptr = remotePluginInputBuffer();
+		m_audioBufferIn.resize(inChannels);
+		for (pi_ch_t idx = 0; idx < inChannels; ++idx)
+		{
+			m_audioBufferIn[idx] = ptr;
+			ptr += frames;
+		}
+
+		ptr = remotePluginOutputBuffer();
+		m_audioBufferOut.resize(outChannels);
+		for (pi_ch_t idx = 0; idx < outChannels; ++idx)
+		{
+			m_audioBufferOut[idx] = ptr;
+			ptr += frames;
+		}
+	}
+
+	auto active() const -> bool final { return m_remotePlugin != nullptr; }
+
+private:
+	// Views into RemotePlugin's shared memory buffer
+	std::vector<SplitSampleType<float>*> m_audioBufferIn;
+	std::vector<SplitSampleType<float>*> m_audioBufferOut;
+};
+
+
+} // namespace lmms
+
+#endif // LMMS_REMOTE_PLUGIN_AUDIO_PORT_H

--- a/include/RemotePluginAudioPort.h
+++ b/include/RemotePluginAudioPort.h
@@ -98,7 +98,7 @@ public:
 	}
 
 	static_assert(config.kind == AudioDataKind::F32, "RemotePlugin only supports float");
-	static_assert(config.layout == AudioDataLayout::Split, "RemotePlugin only supports non-interleaved");
+	static_assert(config.interleaved == false, "RemotePlugin only supports non-interleaved");
 	static_assert(!config.inplace, "RemotePlugin does not support inplace processing");
 
 	auto controller() -> RemotePluginAudioPortController&

--- a/include/RemotePluginBase.h
+++ b/include/RemotePluginBase.h
@@ -350,8 +350,6 @@ enum RemoteMessageIDs
 	IdStartProcessing,
 	IdProcessingDone,
 	IdChangeSharedMemoryKey,
-	IdChangeInputCount,
-	IdChangeOutputCount,
 	IdChangeInputOutputCount,
 	IdShowUI,
 	IdHideUI,

--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -84,18 +84,6 @@ public:
 		return m_bufferSize;
 	}
 
-	void setInputCount( int _i )
-	{
-		m_inputCount = _i;
-		sendMessage( message( IdChangeInputCount ).addInt( _i ) );
-	}
-
-	void setOutputCount( int _i )
-	{
-		m_outputCount = _i;
-		sendMessage( message( IdChangeOutputCount ).addInt( _i ) );
-	}
-
 	void setInputOutputCount( int i, int o )
 	{
 		m_inputCount = i;

--- a/include/SampleFrame.h
+++ b/include/SampleFrame.h
@@ -227,6 +227,10 @@ inline void copyFromSampleFrames(InterleavedSampleType<float>* target, const Sam
 	}
 }
 
+// Enable `SampleFrame` to use the AudioDataType metafunction
+namespace detail {
+template<> struct AudioDataType<AudioDataKind::SampleFrame> { using type = SampleFrame; };
+} // namespace detail
 
 //! A non-owning `SampleFrame` buffer (interleaved, 2-channel)
 using CoreAudioData = Span<const SampleFrame>;

--- a/include/SampleFrame.h
+++ b/include/SampleFrame.h
@@ -53,12 +53,14 @@ public:
 	{
 	}
 
-	InterleavedSampleType<sample_t>* data()
+	//! 2 channels, interleaved
+	sample_t* data()
 	{
 		return m_samples.data();
 	}
 
-	const InterleavedSampleType<sample_t>* data() const
+	//! 2 channels, interleaved
+	const sample_t* data() const
 	{
 		return m_samples.data();
 	}
@@ -186,7 +188,7 @@ public:
 	}
 
 private:
-	std::array<InterleavedSampleType<sample_t>, DEFAULT_CHANNELS> m_samples;
+	std::array<sample_t, DEFAULT_CHANNELS> m_samples;
 };
 
 inline void zeroSampleFrames(SampleFrame* buffer, size_t frames)
@@ -209,7 +211,8 @@ inline SampleFrame getAbsPeakValues(SampleFrame* buffer, size_t frames)
 	return peaks;
 }
 
-inline void copyToSampleFrames(SampleFrame* target, const InterleavedSampleType<float>* source, size_t frames)
+//! `source` is 2-channel interleaved data with length of 2 * `frames`
+inline void copyToSampleFrames(SampleFrame* target, const float* source, size_t frames)
 {
 	for (size_t i = 0; i < frames; ++i)
 	{
@@ -218,7 +221,8 @@ inline void copyToSampleFrames(SampleFrame* target, const InterleavedSampleType<
 	}
 }
 
-inline void copyFromSampleFrames(InterleavedSampleType<float>* target, const SampleFrame* source, size_t frames)
+//! `target` is 2-channel interleaved data with length of 2 * `frames`
+inline void copyFromSampleFrames(float* target, const SampleFrame* source, size_t frames)
 {
 	for (size_t i = 0; i < frames; ++i)
 	{
@@ -227,12 +231,12 @@ inline void copyFromSampleFrames(InterleavedSampleType<float>* target, const Sam
 	}
 }
 
-// Enable `SampleFrame` to use the AudioDataType metafunction
+// Enable SampleFrame to use the AudioDataType metafunction
 namespace detail {
 template<> struct AudioDataType<AudioDataKind::SampleFrame> { using type = SampleFrame; };
 } // namespace detail
 
-//! A non-owning `SampleFrame` buffer (interleaved, 2-channel)
+//! A non-owning SampleFrame buffer (interleaved, 2-channel)
 using CoreAudioData = Span<const SampleFrame>;
 
 //! Mutable CoreAudioData

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -122,6 +122,7 @@ public:
 		else { return extents; }
 	}
 	constexpr auto size_bytes() const -> std::size_t { return size() * sizeof(T); } // NOLINT
+	constexpr auto empty() const -> bool { return size() == 0; }
 
 	constexpr auto operator[](std::size_t idx) const -> const T& { return m_data[idx]; }
 	constexpr auto operator[](std::size_t idx) -> T& { return m_data[idx]; }

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -284,7 +284,7 @@ static int sid_fillbuffer(unsigned char* sidreg, reSID::SID *sid, int tdelta, sh
 
 
 
-
+// TODO: The real sample type is `short` and there is only one output channel
 void SidInstrument::playNoteImpl(NotePlayHandle* _n, CoreAudioDataMut out)
 {
 	const int clockrate = C64_PAL_CYCLES_PER_SEC;

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -365,7 +365,7 @@ void VestigeInstrument::loadFile( const QString & _file )
 	}
 
 	m_pluginMutex.lock();
-	m_plugin = new VstInstrumentPlugin{m_pluginDLL, pinConnector(), this};
+	m_plugin = new VstInstrumentPlugin{m_pluginDLL, audioPort().controller(), this};
 	if( m_plugin->failed() )
 	{
 		m_pluginMutex.unlock();
@@ -474,15 +474,6 @@ void VestigeInstrument::closePlugin( void )
 	delete m_plugin;
 	m_plugin = nullptr;
 	m_pluginMutex.unlock();
-}
-
-
-
-
-auto VestigeInstrument::bufferInterface() -> AudioPluginBufferInterface<AudioDataLayout::Split, float,
-	DynamicChannelCount, DynamicChannelCount>*
-{
-	return m_plugin;
 }
 
 

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -365,7 +365,7 @@ void VestigeInstrument::loadFile( const QString & _file )
 	}
 
 	m_pluginMutex.lock();
-	m_plugin = new VstInstrumentPlugin{m_pluginDLL, audioPort().controller(), this};
+	m_plugin = new VstInstrumentPlugin{m_pluginDLL, audioPort().controller()};
 	if( m_plugin->failed() )
 	{
 		m_pluginMutex.unlock();

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -32,6 +32,7 @@
 
 #include "AudioPlugin.h"
 #include "InstrumentView.h"
+#include "RemotePluginAudioPort.h"
 
 
 class QPixmap;
@@ -55,9 +56,13 @@ class VestigeInstrumentView;
 } // namespace gui
 
 
+constexpr auto VestigeConfig = AudioPluginConfig {
+	.kind = AudioDataKind::F32,
+	.layout = AudioDataLayout::Split
+};
+
 class VestigeInstrument
-	: public AudioPlugin<Instrument, float,
-		PluginConfig{ .layout = AudioDataLayout::Split, .customBuffer = true }>
+	: public AudioPlugin<Instrument, VestigeConfig, RemotePluginAudioPort<VestigeConfig>>
 {
 	Q_OBJECT
 public:
@@ -84,9 +89,6 @@ protected slots:
 
 private:
 	void closePlugin();
-
-	auto bufferInterface() -> AudioPluginBufferInterface<AudioDataLayout::Split, float,
-		DynamicChannelCount, DynamicChannelCount>* override;
 
 	VstPlugin * m_plugin;
 	QMutex m_pluginMutex;

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -58,7 +58,7 @@ class VestigeInstrumentView;
 
 constexpr auto VestigeConfig = AudioPluginConfig {
 	.kind = AudioDataKind::F32,
-	.layout = AudioDataLayout::Split
+	.interleaved = false
 };
 
 class VestigeInstrument

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -53,7 +53,7 @@
 #include "LocaleHelper.h"
 #include "MainWindow.h"
 #include "PathUtil.h"
-#include "PluginPinConnector.h"
+#include "RemotePluginAudioPort.h"
 #include "Song.h"
 #include "FileDialog.h"
 
@@ -267,7 +267,7 @@ void VstPlugin::loadSettings( const QDomElement & _this )
 		setParameterDump( dump );
 	}
 
-	audioPortController()->pinConnector().loadSettings(_this);
+	audioPortController()->pc().loadSettings(_this);
 }
 
 
@@ -311,7 +311,7 @@ void VstPlugin::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	}
 
 	_this.setAttribute( "program", currentProgram() );
-	audioPortController()->pinConnector().saveSettings(_doc, _this);
+	audioPortController()->pc().saveSettings(_doc, _this);
 }
 
 void VstPlugin::toggleUI()

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -122,8 +122,8 @@ enum class ExecutableType
 	Unknown, Win32, Win64, Linux64,
 };
 
-VstPlugin::VstPlugin(const QString& plugin, RemotePluginAudioPortController& controller, Model* parent)
-	: RemotePlugin{controller, parent}
+VstPlugin::VstPlugin(const QString& plugin, RemotePluginAudioPortController& audioPort)
+	: RemotePlugin{audioPort}
 	, m_plugin{PathUtil::toAbsolute(plugin)}
 	, m_pluginWindowID{0}
 	, m_embedMethod{(gui::getGUI() != nullptr)
@@ -267,7 +267,7 @@ void VstPlugin::loadSettings( const QDomElement & _this )
 		setParameterDump( dump );
 	}
 
-	audioPortController()->pc().loadSettings(_this);
+	audioPort()->pc().loadSettings(_this);
 }
 
 
@@ -311,7 +311,7 @@ void VstPlugin::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	}
 
 	_this.setAttribute( "program", currentProgram() );
-	audioPortController()->pc().saveSettings(_doc, _this);
+	audioPort()->pc().saveSettings(_doc, _this);
 }
 
 void VstPlugin::toggleUI()

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -162,8 +162,6 @@ VstPlugin::VstPlugin(const QString& plugin, RemotePluginAudioPortController& aud
 		}
 	}
 
-
-
 	switch(pluginType)
 	{
 	case ExecutableType::Win64:

--- a/plugins/VstBase/VstPlugin.h
+++ b/plugins/VstBase/VstPlugin.h
@@ -47,7 +47,7 @@ class VSTBASE_EXPORT VstPlugin
 {
 	Q_OBJECT
 public:
-	VstPlugin(const QString& plugin, RemotePluginAudioPortController& controller, Model* parent = nullptr);
+	VstPlugin(const QString& plugin, RemotePluginAudioPortController& audioPort);
 	~VstPlugin() override;
 
 	void tryLoad( const QString &remoteVstPluginExecutable );

--- a/plugins/VstBase/VstPlugin.h
+++ b/plugins/VstBase/VstPlugin.h
@@ -33,14 +33,13 @@
 
 #include "JournallingObject.h"
 #include "RemotePlugin.h"
-#include "RemotePluginAudioPort.h"
 
 #include "vstbase_export.h"
 
 namespace lmms
 {
 
-class PluginPinConnector;
+class RemotePluginAudioPortController;
 
 class VSTBASE_EXPORT VstPlugin
 	: public RemotePlugin

--- a/plugins/VstBase/VstPlugin.h
+++ b/plugins/VstBase/VstPlugin.h
@@ -31,9 +31,9 @@
 #include <QString>
 #include <QTimer>
 
-#include "AudioPluginBuffer.h"
 #include "JournallingObject.h"
 #include "RemotePlugin.h"
+#include "RemotePluginAudioPort.h"
 
 #include "vstbase_export.h"
 
@@ -45,11 +45,10 @@ class PluginPinConnector;
 class VSTBASE_EXPORT VstPlugin
 	: public RemotePlugin
 	, public JournallingObject
-	, public AudioPluginBufferInterface<AudioDataLayout::Split, float, DynamicChannelCount, DynamicChannelCount>
 {
 	Q_OBJECT
 public:
-	VstPlugin(const QString& plugin, PluginPinConnector* pinConnector, Model* parent = nullptr);
+	VstPlugin(const QString& plugin, RemotePluginAudioPortController& controller, Model* parent = nullptr);
 	~VstPlugin() override;
 
 	void tryLoad( const QString &remoteVstPluginExecutable );
@@ -128,12 +127,6 @@ public:
 
 	QString embedMethod() const;
 
-	auto inputBuffer() -> SplitAudioData<float> override;
-	auto outputBuffer() -> SplitAudioData<float> override;
-	void updateBuffers(int channelsIn, int channelsOut) override;
-
-	void bufferUpdated() override;
-
 public slots:
 	void setTempo( lmms::bpm_t _bpm );
 	void updateSampleRate();
@@ -181,10 +174,6 @@ private:
 	int m_currentProgram;
 
 	QTimer m_idleTimer;
-
-	// Views into RemotePlugin's shared memory buffer
-	std::vector<SplitSampleType<float>*> m_audioBufferIn;
-	std::vector<SplitSampleType<float>*> m_audioBufferOut;
 };
 
 

--- a/plugins/VstEffect/VstEffect.cpp
+++ b/plugins/VstEffect/VstEffect.cpp
@@ -98,7 +98,10 @@ auto VstEffect::processImpl() -> ProcessStatus
 	// Wet/dry mixing only applies to those channels and any additional
 	// channels remain as-is.
 
-	const auto in = m_plugin->inputBuffer();
+	auto buffers = audioPort().buffers();
+	assert(buffers != nullptr);
+
+	const auto in = buffers->inputBuffer();
 	if (in.channels() == 0)
 	{
 		// Do not process wet/dry for an instrument loaded as an effect
@@ -106,7 +109,7 @@ auto VstEffect::processImpl() -> ProcessStatus
 		return ProcessStatus::ContinueIfNotQuiet;
 	}
 
-	auto out = m_plugin->outputBuffer();
+	auto out = buffers->outputBuffer();
 
 	const float w = wetLevel();
 	const float d = dryLevel();
@@ -128,15 +131,6 @@ auto VstEffect::processImpl() -> ProcessStatus
 
 
 
-auto VstEffect::bufferInterface() -> AudioPluginBufferInterface<AudioDataLayout::Split, float,
-	DynamicChannelCount, DynamicChannelCount>*
-{
-	return m_plugin.get();
-}
-
-
-
-
 bool VstEffect::openPlugin(const QString& plugin)
 {
 	gui::TextFloat* tf = nullptr;
@@ -149,7 +143,7 @@ bool VstEffect::openPlugin(const QString& plugin)
 	}
 
 	QMutexLocker ml( &m_pluginMutex ); Q_UNUSED( ml );
-	m_plugin = QSharedPointer<VstPlugin>(new VstPlugin{plugin, pinConnector(), this});
+	m_plugin = QSharedPointer<VstPlugin>(new VstPlugin{plugin, audioPort().controller(), this});
 	if( m_plugin->failed() )
 	{
 		m_plugin.clear();

--- a/plugins/VstEffect/VstEffect.cpp
+++ b/plugins/VstEffect/VstEffect.cpp
@@ -143,7 +143,7 @@ bool VstEffect::openPlugin(const QString& plugin)
 	}
 
 	QMutexLocker ml( &m_pluginMutex ); Q_UNUSED( ml );
-	m_plugin = QSharedPointer<VstPlugin>(new VstPlugin{plugin, audioPort().controller(), this});
+	m_plugin = QSharedPointer<VstPlugin>(new VstPlugin{plugin, audioPort().controller()});
 	if( m_plugin->failed() )
 	{
 		m_plugin.clear();

--- a/plugins/VstEffect/VstEffect.h
+++ b/plugins/VstEffect/VstEffect.h
@@ -39,7 +39,7 @@ class VstPlugin;
 
 constexpr auto VstEffectConfig = AudioPluginConfig {
 	.kind = AudioDataKind::F32,
-	.layout = AudioDataLayout::Split
+	.interleaved = false
 };
 
 class VstEffect : public AudioPlugin<Effect, VstEffectConfig, RemotePluginAudioPort<VstEffectConfig>>

--- a/plugins/VstEffect/VstEffect.h
+++ b/plugins/VstEffect/VstEffect.h
@@ -29,6 +29,7 @@
 #include <QSharedPointer>
 
 #include "AudioPlugin.h"
+#include "RemotePluginAudioPort.h"
 #include "VstEffectControls.h"
 
 namespace lmms
@@ -36,9 +37,12 @@ namespace lmms
 
 class VstPlugin;
 
-class VstEffect
-	: public AudioPlugin<Effect, float,
-		PluginConfig{ .layout = AudioDataLayout::Split, .customBuffer = true }>
+constexpr auto VstEffectConfig = AudioPluginConfig {
+	.kind = AudioDataKind::F32,
+	.layout = AudioDataLayout::Split
+};
+
+class VstEffect : public AudioPlugin<Effect, VstEffectConfig, RemotePluginAudioPort<VstEffectConfig>>
 {
 public:
 	VstEffect( Model * _parent,
@@ -54,9 +58,6 @@ public:
 
 
 private:
-	auto bufferInterface() -> AudioPluginBufferInterface<AudioDataLayout::Split, float,
-		DynamicChannelCount, DynamicChannelCount>* override;
-
 	//! Returns true if plugin was loaded (m_plugin != nullptr)
 	bool openPlugin(const QString& plugin);
 	void closePlugin();

--- a/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
@@ -58,7 +58,7 @@ public:
 	{
 		Nio::start();
 
-		setInputCount( 0 );
+		setInputOutputCount(0, 2);
 		sendMessage( IdInitDone );
 		waitForMessage( IdInitDone );
 
@@ -144,7 +144,8 @@ public:
 	void process(const float* in, float* out) override
 	{
 		(void)in;
-		auto output = SplitAudioData<float, 2>{&out, 2, bufferSize()};
+		auto accessBuffer = std::array{out, out + bufferSize()};
+		auto output = SplitAudioData<float, 2>{accessBuffer.data(), 2, bufferSize()};
 		LocalZynAddSubFx::process(output);
 	}
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -77,8 +77,8 @@ Plugin::Descriptor PLUGIN_EXPORT zynaddsubfx_plugin_descriptor =
 
 
 
-ZynAddSubFxRemotePlugin::ZynAddSubFxRemotePlugin(RemotePluginAudioPortController& controller)
-	: RemotePlugin{controller}
+ZynAddSubFxRemotePlugin::ZynAddSubFxRemotePlugin(RemotePluginAudioPortController& audioPort)
+	: RemotePlugin{audioPort}
 {
 	init( "RemoteZynAddSubFx", false );
 }

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -459,10 +459,6 @@ void ZynAddSubFxInstrument::initPlugin()
 
 		m_remotePlugin->updateSampleRate( Engine::audioEngine()->outputSampleRate() );
 
-		// temporary workaround until the VST synchronization feature gets stripped out of the RemotePluginClient class
-		// causing not to send buffer size information requests
-		//m_remotePlugin->sendMessage( RemotePlugin::message( IdBufferSizeInformation ).addInt( Engine::audioEngine()->framesPerPeriod() ) );
-
 		m_remotePlugin->showUI();
 		m_remotePlugin->unlock();
 	}

--- a/plugins/ZynAddSubFx/ZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.h
@@ -60,7 +60,7 @@ class ZynAddSubFxRemotePlugin
 {
 	Q_OBJECT
 public:
-	ZynAddSubFxRemotePlugin(RemotePluginAudioPortController& controller);
+	ZynAddSubFxRemotePlugin(RemotePluginAudioPortController& audioPort);
 
 	bool processMessage( const message & _m ) override;
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.h
@@ -33,9 +33,11 @@
 #include <globals.h>
 
 #include "AudioPlugin.h"
+#include "AudioPluginBuffer.h"
 #include "AutomatableModel.h"
 #include "InstrumentView.h"
 #include "RemotePlugin.h"
+#include "RemotePluginAudioPort.h"
 
 class QPushButton;
 
@@ -55,29 +57,28 @@ class ZynAddSubFxView;
 
 class ZynAddSubFxRemotePlugin
 	: public RemotePlugin
-	, public AudioPluginBufferInterface<AudioDataLayout::Split, float, 0, 2>
 {
 	Q_OBJECT
 public:
-	ZynAddSubFxRemotePlugin(PluginPinConnector* pinConnector);
+	ZynAddSubFxRemotePlugin(RemotePluginAudioPortController& controller);
 
 	bool processMessage( const message & _m ) override;
 
-	auto inputBuffer() -> SplitAudioData<float, 0> override;
-	auto outputBuffer() -> SplitAudioData<float, 2> override;
-	void updateBuffers(int channelsIn, int channelsOut) override;
-
 signals:
 	void clickedCloseButton();
+};
 
-private:
-	std::array<float*, 2> m_accessBuffer;
+
+constexpr auto ZynConfig = AudioPluginConfig {
+	.kind = AudioDataKind::F32,
+	.layout = AudioDataLayout::Split,
+	.inputs = 0,
+	.outputs = 2
 };
 
 
 class ZynAddSubFxInstrument
-	: public AudioPlugin<Instrument, float,
-		PluginConfig{ .layout = AudioDataLayout::Split, .inputs = 0, .outputs = 2, .customBuffer = true }>
+	: public AudioPlugin<Instrument, ZynConfig, ConfigurableAudioPort<ZynConfig>>
 {
 	Q_OBJECT
 public:
@@ -97,8 +98,6 @@ public:
 	QString nodeName() const override;
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
-
-	auto bufferInterface() -> AudioPluginBufferInterface<AudioDataLayout::Split, float, 0, 2>* override;
 
 private slots:
 	void reloadPlugin();
@@ -122,9 +121,6 @@ private:
 	QMutex m_pluginMutex;
 	LocalZynAddSubFx * m_localPlugin;
 	ZynAddSubFxRemotePlugin * m_remotePlugin;
-
-	// LocalZynAddSubFx needs to be supplied with a buffer
-	std::optional<AudioPluginBufferDefaultImpl<AudioDataLayout::Split, float, 0, 2, false>> m_localPluginBuffer;
 
 	FloatModel m_portamentoModel;
 	FloatModel m_filterFreqModel;

--- a/plugins/ZynAddSubFx/ZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.h
@@ -71,7 +71,7 @@ signals:
 
 constexpr auto ZynConfig = AudioPluginConfig {
 	.kind = AudioDataKind::F32,
-	.layout = AudioDataLayout::Split,
+	.interleaved = false,
 	.inputs = 0,
 	.outputs = 2
 };

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -65,6 +65,7 @@ set(LMMS_SRCS
 	core/ProjectRenderer.cpp
 	core/ProjectVersion.cpp
 	core/RemotePlugin.cpp
+	core/RemotePluginAudioPort.cpp
 	core/RenderManager.cpp
 	core/RingBuffer.cpp
 	core/Sample.cpp

--- a/src/core/PluginPinConnector.cpp
+++ b/src/core/PluginPinConnector.cpp
@@ -64,11 +64,7 @@ void PluginPinConnector::setPluginChannelCounts(int inCount, int outCount)
 {
 	setPluginChannelCountsImpl(inCount, outCount);
 
-	/*
-	 * Now tell the audio buffer to update.
-	 * NOTE: This method does not call the implementation in the audio port until
-	 *       the audio port is fully constructed
-	 */
+	// Now tell the audio buffer to update
 	bufferPropertiesChanged(inCount, outCount, Engine::audioEngine()->framesPerPeriod());
 
 	emit propertiesChanged();

--- a/src/core/PluginPinConnector.cpp
+++ b/src/core/PluginPinConnector.cpp
@@ -2,7 +2,7 @@
  * PluginPinConnector.cpp - Specifies how to route audio channels
  *                          in and out of a plugin.
  *
- * Copyright (c) 2024 Dalton Messmer <messmer.dalton/at/gmail.com>
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -41,26 +41,23 @@ PluginPinConnector::PluginPinConnector(bool isInstrument, Model* parent)
 	: Model{parent}
 	, m_isInstrument{isInstrument}
 {
-	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged, this, &PluginPinConnector::pluginBuffersChanged);
 	setTrackChannelCount(s_totalTrackChannels);
+
+	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged, [this]() {
+		bufferPropertiesChanged(in().channelCount(), out().channelCount(), Engine::audioEngine()->framesPerPeriod());
+	});
 }
 
 PluginPinConnector::PluginPinConnector(int pluginChannelCountIn, int pluginChannelCountOut, bool isInstrument, Model* parent)
 	: Model{parent}
 	, m_isInstrument{isInstrument}
 {
-	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged, this, &PluginPinConnector::pluginBuffersChanged);
 	setTrackChannelCount(s_totalTrackChannels);
+	setPluginChannelCounts(pluginChannelCountIn, pluginChannelCountOut);
 
-	if (pluginChannelCountIn == 0 && pluginChannelCountOut == 0)
-	{
-		throw std::invalid_argument{"At least one port count must be non-zero"};
-	}
-
-	if (pluginChannelCountIn != DynamicChannelCount || pluginChannelCountOut != DynamicChannelCount)
-	{
-		setPluginChannelCounts(pluginChannelCountIn, pluginChannelCountOut);
-	}
+	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged, [this]() {
+		bufferPropertiesChanged(in().channelCount(), out().channelCount(), Engine::audioEngine()->framesPerPeriod());
+	});
 }
 
 void PluginPinConnector::setPluginChannelCounts(int inCount, int outCount)
@@ -68,6 +65,11 @@ void PluginPinConnector::setPluginChannelCounts(int inCount, int outCount)
 	if (m_trackChannelsUpperBound > MaxTrackChannels)
 	{
 		throw std::runtime_error{"Only up to 256 track channels are allowed"};
+	}
+
+	if (inCount == DynamicChannelCount || outCount != DynamicChannelCount)
+	{
+		return;
 	}
 
 	if (inCount < 0)
@@ -97,8 +99,14 @@ void PluginPinConnector::setPluginChannelCounts(int inCount, int outCount)
 	m_in.setPluginChannelCount(this, inCount, QString::fromUtf16(u"Pin in [%1 \U0001F82E %2]"));
 	m_out.setPluginChannelCount(this, outCount, QString::fromUtf16(u"Pin out [%2 \U0001F82E %1]"));
 
+	/*
+	 * Now tell the audio buffer to update.
+	 * NOTE: This method does not call the implementation in the audio port until
+	 *       the audio port is fully constructed
+	 */
+	bufferPropertiesChanged(inCount, outCount, Engine::audioEngine()->framesPerPeriod());
+
 	emit propertiesChanged();
-	emit pluginBuffersChanged();
 }
 
 void PluginPinConnector::setPluginChannelCountIn(int inCount)

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -142,11 +142,11 @@ RemotePlugin::RemotePlugin(RemotePluginAudioPortController& controller, Model* p
 	, RemotePluginBase{}
 #endif
 	, m_failed{true}
-	, m_audioPortController{&controller}
 	, m_watcher{this}
 #if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 	, m_commMutex{QMutex::Recursive}
 #endif
+	, m_audioPortController{&controller}
 {
 #ifndef SYNC_WITH_SHM_FIFO
 	struct sockaddr_un sa;
@@ -502,15 +502,15 @@ bool RemotePlugin::processMessage( const message & _m )
 			break;
 
 		case IdChangeInputCount:
-			m_audioPortController->pinConnector().setPluginChannelCountIn(_m.getInt(0));
+			m_audioPortController->pc().setPluginChannelCountIn(_m.getInt(0));
 			break;
 
 		case IdChangeOutputCount:
-			m_audioPortController->pinConnector().setPluginChannelCountOut(_m.getInt(0));
+			m_audioPortController->pc().setPluginChannelCountOut(_m.getInt(0));
 			break;
 
 		case IdChangeInputOutputCount:
-			m_audioPortController->pinConnector().setPluginChannelCounts(_m.getInt(0), _m.getInt(1));
+			m_audioPortController->pc().setPluginChannelCounts(_m.getInt(0), _m.getInt(1));
 			break;
 
 		case IdDebugMessage:

--- a/src/core/RemotePluginAudioPort.cpp
+++ b/src/core/RemotePluginAudioPort.cpp
@@ -24,16 +24,12 @@
 
 #include "RemotePluginAudioPort.h"
 
-#include "AudioEngine.h"
-#include "Engine.h"
 #include "RemotePlugin.h"
-#include "lmms_basics.h"
 
 namespace lmms {
 
 RemotePluginAudioPortController::RemotePluginAudioPortController(PluginPinConnector& pinConnector)
 	: m_pinConnector{&pinConnector}
-	, m_frames{Engine::audioEngine()->framesPerPeriod()}
 {
 }
 

--- a/src/core/RemotePluginAudioPort.cpp
+++ b/src/core/RemotePluginAudioPort.cpp
@@ -39,20 +39,20 @@ RemotePluginAudioPortController::RemotePluginAudioPortController(PluginPinConnec
 
 void RemotePluginAudioPortController::remotePluginUpdateBuffers(int channelsIn, int channelsOut, fpp_t frames)
 {
-	assert(m_remotePlugin != nullptr);
-	m_remotePlugin->updateBuffer(channelsIn, channelsOut, frames);
+	assert(m_buffers != nullptr);
+	m_buffers->updateBuffer(channelsIn, channelsOut, frames);
 }
 
 auto RemotePluginAudioPortController::remotePluginInputBuffer() const -> float*
 {
-	assert(m_remotePlugin != nullptr);
-	return m_remotePlugin->inputBuffer().data();
+	assert(m_buffers != nullptr);
+	return m_buffers->inputBuffer().data();
 }
 
 auto RemotePluginAudioPortController::remotePluginOutputBuffer() const -> float*
 {
-	assert(m_remotePlugin != nullptr);
-	return m_remotePlugin->outputBuffer().data();
+	assert(m_buffers != nullptr);
+	return m_buffers->outputBuffer().data();
 }
 
 } // namespace lmms

--- a/src/core/RemotePluginAudioPort.cpp
+++ b/src/core/RemotePluginAudioPort.cpp
@@ -1,0 +1,58 @@
+/*
+ * RemotePluginAudioPort.cpp - PluginAudioPort implementation for RemotePlugin
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "RemotePluginAudioPort.h"
+
+#include "AudioEngine.h"
+#include "Engine.h"
+#include "RemotePlugin.h"
+#include "lmms_basics.h"
+
+namespace lmms {
+
+RemotePluginAudioPortController::RemotePluginAudioPortController(PluginPinConnector& pinConnector)
+	: m_pinConnector{&pinConnector}
+	, m_frames{Engine::audioEngine()->framesPerPeriod()}
+{
+}
+
+void RemotePluginAudioPortController::remotePluginUpdateBuffers(int channelsIn, int channelsOut, fpp_t frames)
+{
+	assert(m_remotePlugin != nullptr);
+	m_remotePlugin->updateBuffer(channelsIn, channelsOut, frames);
+}
+
+auto RemotePluginAudioPortController::remotePluginInputBuffer() const -> float*
+{
+	assert(m_remotePlugin != nullptr);
+	return m_remotePlugin->inputBuffer().data();
+}
+
+auto RemotePluginAudioPortController::remotePluginOutputBuffer() const -> float*
+{
+	assert(m_remotePlugin != nullptr);
+	return m_remotePlugin->outputBuffer().data();
+}
+
+} // namespace lmms

--- a/src/gui/PluginPinConnectorView.cpp
+++ b/src/gui/PluginPinConnectorView.cpp
@@ -1,7 +1,7 @@
 /*
  * PluginPinConnectorView.cpp - Displays pin connectors
  *
- * Copyright (c) 2024 Dalton Messmer <messmer.dalton/at/gmail.com>
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/tests/src/core/PluginPinConnectorTest.cpp
+++ b/tests/src/core/PluginPinConnectorTest.cpp
@@ -383,7 +383,7 @@ private slots:
 		trackChannels[33].setRight(987.f);
 
 		// Plugin input and output buffers
-		auto bufferSplit1x1 = AudioPluginBufferDefaultImpl<Config>{};
+		auto bufferSplit1x1 = DefaultAudioPluginBuffer<Config>{};
 		auto ins = bufferSplit1x1.inputBuffer();
 		auto outs = bufferSplit1x1.outputBuffer();
 
@@ -443,7 +443,7 @@ private slots:
 		trackChannels[33].setRight(987.f);
 
 		// Plugin input and output buffers
-		auto bufferSplit2x2 = AudioPluginBufferDefaultImpl<Config>{};
+		auto bufferSplit2x2 = DefaultAudioPluginBuffer<Config>{};
 		auto ins = bufferSplit2x2.inputBuffer();
 		auto outs = bufferSplit2x2.outputBuffer();
 
@@ -530,7 +530,7 @@ private slots:
 		trackChannels[33].setRight(987.f);
 
 		// Plugin input and output buffers
-		auto bufferSplit2x2 = AudioPluginBufferDefaultImpl<Config>{};
+		auto bufferSplit2x2 = DefaultAudioPluginBuffer<Config>{};
 		auto ins = bufferSplit2x2.inputBuffer();
 		auto outs = bufferSplit2x2.outputBuffer();
 
@@ -599,7 +599,7 @@ private slots:
 		trackChannels[33].setRight(987.f);
 
 		// Plugin input and output buffers
-		auto pluginBuffers = AudioPluginBufferDefaultImpl<Config>{};
+		auto pluginBuffers = DefaultAudioPluginBuffer<Config>{};
 		auto inOut = pluginBuffers.inputOutputBuffer();
 
 		// Route to plugin
@@ -676,7 +676,7 @@ private slots:
 		trackChannels[33].setRight(987.f);
 
 		// Plugin input and output buffers
-		auto bufferSplit1x2 = AudioPluginBufferDefaultImpl<Config>{};
+		auto bufferSplit1x2 = DefaultAudioPluginBuffer<Config>{};
 		auto ins = bufferSplit1x2.inputBuffer();
 		auto outs = bufferSplit1x2.outputBuffer();
 

--- a/tests/src/core/PluginPinConnectorTest.cpp
+++ b/tests/src/core/PluginPinConnectorTest.cpp
@@ -356,7 +356,7 @@ private slots:
 		using namespace lmms;
 
 		// Setup
-		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, AudioDataLayout::Split, 1, 1};
+		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, false, 1, 1};
 		auto model = Model{nullptr};
 		auto pc = PluginPinConnector{1, 1, false, &model};
 		auto coreBus = getCoreBus();
@@ -428,7 +428,7 @@ private slots:
 		using namespace lmms;
 
 		// Setup
-		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, AudioDataLayout::Split, 2, 2};
+		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, false, 2, 2};
 		auto model = Model{nullptr};
 		auto pc = PluginPinConnector{Config.inputs, Config.outputs, false, &model};
 		auto coreBus = getCoreBus();
@@ -500,7 +500,7 @@ private slots:
 		using namespace lmms;
 
 		// Setup
-		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, AudioDataLayout::Split, 2, 2};
+		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, false, 2, 2};
 		auto model = Model{nullptr};
 		auto pc = PluginPinConnector{Config.inputs, Config.outputs, false, &model};
 		auto coreBus = getCoreBus();
@@ -583,7 +583,7 @@ private slots:
 
 		// Setup
 		constexpr auto Config = AudioPluginConfig {
-			AudioDataKind::SampleFrame, AudioDataLayout::Interleaved, 2, 2, true
+			AudioDataKind::SampleFrame, true, 2, 2, true
 		};
 		auto model = Model{nullptr};
 		auto pc = PluginPinConnector{Config.inputs, Config.outputs, false, &model};
@@ -647,7 +647,7 @@ private slots:
 		using namespace lmms;
 
 		// Setup
-		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, AudioDataLayout::Split, 1, 2};
+		constexpr auto Config = AudioPluginConfig{AudioDataKind::F32, false, 1, 2};
 		auto model = Model{nullptr};
 		auto pc = PluginPinConnector{Config.inputs, Config.outputs, false, &model};
 		auto coreBus = getCoreBus();


### PR DESCRIPTION
Fixes some of the jank left over from the big refactor.

## Changes
- **`PluginAudioPort`** - New interface class that joins a pin connector together with a buffer interface.
  - The pin connector, as the base class, can now call the virtual `bufferPropertiesChanged` to directly update the buffer in the derived class. This coupling of two closely related components eliminates the need for janky signal/slot connections.
  - **`DefaultPluginAudioPort`** is the default implementation and it uses `DefaultAudioPluginBuffer`.
  - The plugin audio port design is very flexible in its capabilities while also being very easy to use by plugin implementations. For a custom audio port, simply implement `CustomPluginAudioPort`.
- **`RemotePluginAudioPort`** is a custom plugin audio port implementation for plugins that use `RemotePlugin` (VSTs and Zyn). It has an "inactive" state where the buffer is unavailable (such as when Vestige has no VST loaded).
- **`ConfigurableAudioPort`** is a custom plugin audio port implementation that builds on top of `RemotePluginAudioPort` to offer the choice between a remote buffer or a local buffer at runtime. This is used by ZynAddSubFX which uses a remote buffer when the GUI is open and a local buffer when it is closed. In the future, `ConfigurableAudioPort` should also be helpful in adding sandboxing support for plugins to run either in a separate process or directly in the LMMS process.
- **`AudioDataKind`** - All supported sample types are encoded into this enum. Allows all plugin config information to be stored in `AudioPluginConfig` - no more `SampleT` type parameter that must accompany it.
  - Using the new `AudioPluginConfig` I was able to greatly simplify a lot of the template parameters throughout the pin connector PR
- Removed the `IdChangeInputCount` and `IdChangeOutputCount` remote plugin messages, because it is simpler to always pass both the input and output counts.
- Removed `AudioDataType` because it was clunky to use, bloated the PR, and without a strong typedef it did nothing that couldn't be accomplished with a comment.
- Various small changes


## Future directions
- `RemotePluginAudioPort` is kind of strange because it partially implements an audio buffer for `RemotePlugin` rather than having its own `RemotePluginAudioBuffer` class which carries that responsibility. In the future a `RemotePluginAudioBuffer` class which implements `PluginAudioBufferInterface` using shared memory should be created. This would require a refactor of `RemotePlugin`, including turning it into a class template. The corresponding `RemotePluginClient` side could receive similar changes. I've explained this idea further in a comment in `RemotePluginAudioPort.h`.