### PR TITLE
Use the pin connector for all instruments

### DIFF
--- a/include/AudioPlugin.h
+++ b/include/AudioPlugin.h
@@ -26,6 +26,7 @@
 #ifndef LMMS_AUDIO_PLUGIN_H
 #define LMMS_AUDIO_PLUGIN_H
 
+#include <concepts>
 #include <type_traits>
 
 #include "Effect.h"
@@ -58,54 +59,81 @@ template<class ParentT, AudioPortsSettings settings,
 	bool inplace = settings.inplace, bool buffered = settings.buffered>
 class AudioProcessingMethod;
 
-//! Instrument specialization
+//! SingleStreamedInstrument specialization
 template<AudioPortsSettings settings>
-class AudioProcessingMethod<Instrument, settings, false, false>
+class AudioProcessingMethod<SingleStreamedInstrument, settings, false, false>
 {
 	using InBufferT = AudioDataViewType<settings, false, true>;
 	using OutBufferT = AudioDataViewType<settings, true, false>;
 
 protected:
-	//! The main audio processing method for NotePlayHandle-based Instruments
-	//! NOTE: NotePlayHandle-based instruments are currently unsupported
-	//virtual void processImpl(NotePlayHandle* nph, InBufferT in, OutBufferT out) {}
-
-	//! The main audio processing method for MIDI-based Instruments
+	//! The main audio processing method for single-streamed instruments
 	virtual void processImpl(InBufferT in, OutBufferT out) = 0;
 };
 
-//! Instrument specialization (in-place)
+//! SingleStreamedInstrument specialization (in-place)
 template<AudioPortsSettings settings>
-class AudioProcessingMethod<Instrument, settings, true, false>
+class AudioProcessingMethod<SingleStreamedInstrument, settings, true, false>
 {
 	using InOutBufferT = AudioDataViewType<settings, false, false>;
 
 protected:
-	//! The main audio processing method for NotePlayHandle-based Instruments
-	//! NOTE: NotePlayHandle-based instruments are currently unsupported
-	//virtual void processImpl(NotePlayHandle* nph, InOutBufferT inOut) {}
-
-	//! The main audio processing method for MIDI-based Instruments
+	//! The main audio processing method for single-streamed instruments
 	virtual void processImpl(InOutBufferT inOut) = 0;
 };
 
-//! Instrument specialization (buffered)
+//! SingleStreamedInstrument specialization (buffered)
 template<AudioPortsSettings settings, bool inplace>
-class AudioProcessingMethod<Instrument, settings, inplace, true>
+class AudioProcessingMethod<SingleStreamedInstrument, settings, inplace, true>
 {
 protected:
 	/**
-	 * The main audio processing method for NotePlayHandle-based Instruments.
-	 * The implementation knows how to provide the working buffers.
-	 * NOTE: NotePlayHandle-based instruments are currently unsupported
-	 */
-	//virtual void processImpl(NotePlayHandle* nph) {}
-
-	/**
-	 * The main audio processing method for MIDI-based Instruments.
+	 * The main audio processing method for single-streamed instruments.
 	 * The implementation knows how to provide the working buffers.
 	 */
 	virtual void processImpl() = 0;
+};
+
+//! SingleStreamedMidiInstrument specialization (same as SingleStreamedInstrument)
+template<AudioPortsSettings settings, bool inplace, bool buffered>
+class AudioProcessingMethod<SingleStreamedMidiInstrument, settings, inplace, buffered>
+	: public AudioProcessingMethod<SingleStreamedInstrument, settings, inplace, buffered>
+{
+};
+
+//! MultiStreamedInstrument specialization
+template<AudioPortsSettings settings>
+class AudioProcessingMethod<MultiStreamedInstrument, settings, false, false>
+{
+	using InBufferT = AudioDataViewType<settings, false, true>;
+	using OutBufferT = AudioDataViewType<settings, true, false>;
+
+protected:
+	//! The main audio processing method for multi-streamed instruments
+	virtual void processImpl(NotePlayHandle* nph, InBufferT in, OutBufferT out) = 0;
+};
+
+//! MultiStreamedInstrument specialization (in-place)
+template<AudioPortsSettings settings>
+class AudioProcessingMethod<MultiStreamedInstrument, settings, true, false>
+{
+	using InOutBufferT = AudioDataViewType<settings, false, false>;
+
+protected:
+	//! The main audio processing method for multi-streamed instruments
+	virtual void processImpl(NotePlayHandle* nph, InOutBufferT inOut) = 0;
+};
+
+//! MultiStreamedInstrument specialization (buffered)
+template<AudioPortsSettings settings, bool inplace>
+class AudioProcessingMethod<MultiStreamedInstrument, settings, inplace, true>
+{
+protected:
+	/**
+	 * The main audio processing method for multi-streamed instruments.
+	 * The implementation knows how to provide the working buffers.
+	 */
+	virtual void processImpl(NotePlayHandle* nph) = 0;
 };
 
 //! Effect specialization
@@ -157,11 +185,11 @@ class AudioPlugin
 	static_assert(always_false_v<ParentT>, "ParentT must be either Instrument or Effect");
 };
 
-//! Instrument specialization
-template<AudioPortsSettings settings, class AudioPortsT>
-class AudioPlugin<Instrument, settings, AudioPortsT>
-	: public Instrument
-	, public AudioProcessingMethod<Instrument, settings>
+//! SingleStreamedInstrument / SingleStreamedMidiInstrument specialization
+template<std::derived_from<SingleStreamedInstrument> InstrumentT, AudioPortsSettings settings, class AudioPortsT>
+class AudioPlugin<InstrumentT, settings, AudioPortsT>
+	: public InstrumentT
+	, public AudioProcessingMethod<InstrumentT, settings>
 {
 public:
 	template<typename... AudioPortsArgsT>
@@ -169,7 +197,7 @@ public:
 		const Plugin::Descriptor::SubPluginFeatures::Key* key = nullptr,
 		Instrument::Flags flags = Instrument::Flag::NoFlags,
 		AudioPortsArgsT&&... audioPortArgs)
-		: Instrument{desc, parent, key, flags}
+		: InstrumentT{desc, parent, key, flags}
 		, m_audioPorts{true, this, std::forward<AudioPortsArgsT>(audioPortArgs)...}
 	{
 		m_audioPorts.init();
@@ -186,7 +214,7 @@ protected:
 			: nullptr;
 	}
 
-	void playImpl(std::span<SampleFrame> inOut) final
+	void processCoreImpl(std::span<SampleFrame> coreInOut) final
 	{
 		if (!m_audioPorts.active())
 		{
@@ -197,8 +225,8 @@ protected:
 		auto buffers = m_audioPorts.buffers();
 		assert(buffers != nullptr);
 
-		SampleFrame* temp = inOut.data();
-		const auto bus = AudioBus<SampleFrame>{&temp, 1, inOut.size()};
+		SampleFrame* temp = coreInOut.data();
+		const auto bus = AudioBus<SampleFrame>{&temp, 1, coreInOut.size()};
 		auto router = m_audioPorts.getRouter();
 
 		router.process(bus, *buffers, [this](auto... buffers) {
@@ -206,17 +234,61 @@ protected:
 		});
 	}
 
-	void playNoteImpl(NotePlayHandle* notesToPlay, std::span<SampleFrame> inOut) final
+private:
+	AudioPortsT m_audioPorts;
+};
+
+//! MultiStreamedInstrument specialization
+template<AudioPortsSettings settings, class AudioPortsT>
+class AudioPlugin<MultiStreamedInstrument, settings, AudioPortsT>
+	: public MultiStreamedInstrument
+	, public AudioProcessingMethod<MultiStreamedInstrument, settings>
+{
+public:
+	template<typename... AudioPortsArgsT>
+	AudioPlugin(const Plugin::Descriptor* desc, InstrumentTrack* parent = nullptr,
+		const Plugin::Descriptor::SubPluginFeatures::Key* key = nullptr,
+		Instrument::Flags flags = Instrument::Flag::NoFlags,
+		AudioPortsArgsT&&... audioPortArgs)
+		: MultiStreamedInstrument{desc, parent, key, flags}
+		, m_audioPorts{true, this, std::forward<AudioPortsArgsT>(audioPortArgs)...}
 	{
-		/**
-		 * NOTE: Only MIDI-based instruments are currently supported by AudioPlugin.
-		 * NotePlayHandle-based instruments use buffers from their play handles, and more work
-		 * would be needed to integrate that system with the AudioPorts::Buffer system
-		 * used by AudioPlugin. AudioPorts::Buffer is also not thread-safe.
-		 *
-		 * The `Instrument::playNote()` method is still called for MIDI-based instruments when
-		 * notes are played, so this method is a no-op.
-		 */
+		m_audioPorts.init();
+	}
+
+protected:
+	auto audioPorts() -> AudioPortsT& { return m_audioPorts; }
+	auto audioPorts() const -> const AudioPortsT& { return m_audioPorts; }
+
+	auto audioPortsModel() const -> const AudioPortsModel* final
+	{
+		// TODO: Enable pin connector GUI once multi-stream instrument buffers
+		//       are supported. The default pin connector routing works with
+		//       multi-stream instruments only because the "direct routing"
+		//       optimization sidesteps the need for plugin buffers.
+		return nullptr;
+	}
+
+	void processCoreImpl(NotePlayHandle* nph, std::span<SampleFrame> coreInOut) final
+	{
+		if (!m_audioPorts.active())
+		{
+			// Plugin is not running
+			return;
+		}
+
+		// TODO: Need to use NPH buffer here
+
+		auto buffers = m_audioPorts.buffers();
+		assert(buffers != nullptr);
+
+		SampleFrame* temp = coreInOut.data();
+		const auto bus = AudioBus<SampleFrame>{&temp, 1, coreInOut.size()};
+		auto router = m_audioPorts.getRouter();
+
+		router.process(bus, *buffers, [=, this](auto... buffers) {
+			this->processImpl(nph, buffers...);
+		});
 	}
 
 private:
@@ -326,7 +398,7 @@ private:
  *
  * A `processImpl` interface method is provided which must be implemented by the plugin implementation.
  *
- * @tparam ParentT Either `Instrument` or `Effect`
+ * @tparam ParentT `SingleStreamedInstrument`, `SingleStreamedMidiInstrument`, `MultiStreamedInstrument`, or `Effect`
  * @tparam settings Compile-time settings to customize `AudioPlugin`
  * @tparam AudioPortsT The plugin's audio port - must fully implement `AudioPorts`
  */
@@ -385,7 +457,7 @@ private:
 /**
  * Same as `AudioPlugin` but the audio port is passed as a template template parameter.
  *
- * @tparam ParentT Either `Instrument` or `Effect`
+ * @tparam ParentT `SingleStreamedInstrument`, `SingleStreamedMidiInstrument`, `MultiStreamedInstrument`, or `Effect`
  * @tparam settings Compile-time settings to customize `AudioPlugin`
  * @tparam AudioPortsT The plugin's audio port - must fully implement `AudioPorts`
  */
@@ -394,8 +466,23 @@ template<class ParentT, AudioPortsSettings settings,
 using AudioPluginExt = AudioPlugin<ParentT, settings, AudioPortsT<settings>>;
 
 
-// NOTE: NotePlayHandle-based instruments are not supported yet
-using DefaultMidiInstrument = AudioPluginExt<Instrument, AudioPortsSettings {
+using DefaultSingleStreamedInstrument = AudioPluginExt<SingleStreamedInstrument, AudioPortsSettings {
+	.kind = AudioDataKind::SampleFrame,
+	.interleaved = true,
+	.inputs = 0,
+	.outputs = 2,
+	.inplace = true,
+	.buffered = false }>;
+
+using DefaultSingleStreamedMidiInstrument = AudioPluginExt<SingleStreamedMidiInstrument, AudioPortsSettings {
+	.kind = AudioDataKind::SampleFrame,
+	.interleaved = true,
+	.inputs = 0,
+	.outputs = 2,
+	.inplace = true,
+	.buffered = false }>;
+
+using DefaultMultiStreamedInstrument = AudioPluginExt<MultiStreamedInstrument, AudioPortsSettings {
 	.kind = AudioDataKind::SampleFrame,
 	.interleaved = true,
 	.inputs = 0,

--- a/include/DummyInstrument.h
+++ b/include/DummyInstrument.h
@@ -46,11 +46,6 @@ public:
 
 	~DummyInstrument() override = default;
 
-	void playNoteImpl(NotePlayHandle*, std::span<SampleFrame> buffer) override
-	{
-		zeroSampleFrames(buffer.data(), buffer.size());
-	}
-
 	void saveSettings( QDomDocument &, QDomElement & ) override
 	{
 	}
@@ -68,7 +63,12 @@ public:
 	{
 		return new gui::InstrumentViewFixedSize( this, _parent );
 	}
-} ;
+
+	void deleteNotePluginData(NotePlayHandle*) override {}
+
+	bool isSingleStreamed() const override { return false; }
+	bool isMidiBased() const override { return false; }
+};
 
 
 } // namespace lmms

--- a/include/InstrumentPlayHandle.h
+++ b/include/InstrumentPlayHandle.h
@@ -31,13 +31,13 @@
 namespace lmms
 {
 
-class Instrument;
+class SingleStreamedInstrument;
 class InstrumentTrack;
 
 class LMMS_EXPORT InstrumentPlayHandle : public PlayHandle
 {
 public:
-	InstrumentPlayHandle(Instrument * instrument, InstrumentTrack* instrumentTrack);
+	InstrumentPlayHandle(SingleStreamedInstrument* instrument);
 
 	~InstrumentPlayHandle() override = default;
 
@@ -51,7 +51,7 @@ public:
 	bool isFromTrack(const Track* track) const override;
 
 private:
-	Instrument* m_instrument;
+	SingleStreamedInstrument* m_instrument;
 };
 
 } // namespace lmms

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -68,7 +68,7 @@ Plugin::Descriptor PLUGIN_EXPORT audiofileprocessor_plugin_descriptor =
 
 
 AudioFileProcessor::AudioFileProcessor( InstrumentTrack * _instrument_track ) :
-	Instrument(&audiofileprocessor_plugin_descriptor, _instrument_track),
+	AudioPlugin(&audiofileprocessor_plugin_descriptor, _instrument_track),
 	m_ampModel( 100, 0, 500, 1, this, tr( "Amplify" ) ),
 	m_startPointModel( 0, 0, 1, 0.0000001f, this, tr( "Start of sample" ) ),
 	m_endPointModel( 1, 0, 1, 0.0000001f, this, tr( "End of sample" ) ),
@@ -105,7 +105,7 @@ AudioFileProcessor::AudioFileProcessor( InstrumentTrack * _instrument_track ) :
 
 
 
-void AudioFileProcessor::playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
+void AudioFileProcessor::processImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
 {
 	const fpp_t frames = nph->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = nph->noteOffset();

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -26,9 +26,9 @@
 #ifndef LMMS_AUDIO_FILE_PROCESSOR_H
 #define LMMS_AUDIO_FILE_PROCESSOR_H
 
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
 #include "ComboBoxModel.h"
-#include "Instrument.h"
 #include "Sample.h"
 #include "LmmsTypes.h"
 
@@ -36,7 +36,7 @@
 namespace lmms
 {
 
-class AudioFileProcessor : public Instrument
+class AudioFileProcessor : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -90,7 +90,7 @@ signals:
 	void sampleUpdated();
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	Sample m_sample;
 

--- a/plugins/BitInvader/BitInvader.cpp
+++ b/plugins/BitInvader/BitInvader.cpp
@@ -133,7 +133,7 @@ sample_t BSynth::nextStringSample( float sample_length )
 
 
 BitInvader::BitInvader( InstrumentTrack * _instrument_track ) :
-	Instrument(&bitinvader_plugin_descriptor, _instrument_track),
+	AudioPlugin(&bitinvader_plugin_descriptor, _instrument_track),
 	m_sampleLength(wavetableSize, 4, wavetableSize, 1, this, tr("Sample length")),
 	m_graph(-1.0f, 1.0f, wavetableSize, this),
 	m_interpolation(false, this, tr("Interpolation")),
@@ -254,7 +254,7 @@ QString BitInvader::nodeName() const
 
 
 
-void BitInvader::playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
+void BitInvader::processImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
 {
 	if (!nph->m_pluginData)
 	{

--- a/plugins/BitInvader/BitInvader.h
+++ b/plugins/BitInvader/BitInvader.h
@@ -27,8 +27,8 @@
 #ifndef BIT_INVADER_H
 #define BIT_INVADER_H
 
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "Graph.h"
 
@@ -67,7 +67,7 @@ private:
 	
 } ;
 
-class BitInvader : public Instrument
+class BitInvader : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -98,7 +98,7 @@ protected slots:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	FloatModel  m_sampleLength;
 	graphModel  m_graph;

--- a/plugins/CarlaBase/Carla.h
+++ b/plugins/CarlaBase/Carla.h
@@ -54,8 +54,8 @@
 #endif
 
 // lmms/include/
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "SubWindow.h"
 
@@ -165,8 +165,8 @@ private:
 
 // -------------------------------------------------------------------
 
-// TODO: Add support for pin connector and variable number of audio input/output ports
-class CARLABASE_EXPORT CarlaInstrument : public Instrument
+// TODO: Add multi-channel support
+class CARLABASE_EXPORT CarlaInstrument : public DefaultSingleStreamedMidiInstrument
 {
     Q_OBJECT
 
@@ -189,7 +189,6 @@ public:
     QString nodeName() const override;
     void saveSettings(QDomDocument& doc, QDomElement& parent) override;
     void loadSettings(const QDomElement& elem) override;
-    bool handleMidiEvent(const MidiEvent& event, const TimePos& time, f_cnt_t offset) override;
     gui::PluginView* instantiateView(QWidget* parent) override;
 
 signals:
@@ -204,7 +203,8 @@ private slots:
     void updateParamModel(uint32_t index);
 
 private:
-	void playImpl(std::span<SampleFrame> out) override;
+	void processImpl(std::span<SampleFrame> out) override;
+	bool handleMidiEventImpl(const MidiEvent& event, const TimePos& time, f_cnt_t offset) override;
 
     const bool kIsPatchbay;
 

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -72,7 +72,7 @@ Plugin::Descriptor PLUGIN_EXPORT freeboy_plugin_descriptor =
 
 
 FreeBoyInstrument::FreeBoyInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&freeboy_plugin_descriptor, _instrument_track),
+	AudioPlugin(&freeboy_plugin_descriptor, _instrument_track),
 
 	m_ch1SweepTimeModel( 4.0f, 0.0f, 7.0f, 1.0f, this, tr( "Sweep time" ) ),
 	m_ch1SweepDirModel( false, this, tr( "Sweep direction" ) ),
@@ -228,7 +228,7 @@ float FreeBoyInstrument::desiredReleaseTimeMs() const
 
 
 
-void FreeBoyInstrument::playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
+void FreeBoyInstrument::processImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
 {
 	const f_cnt_t tfp = nph->totalFramesPlayed();
 	const int samplerate = Engine::audioEngine()->outputSampleRate();

--- a/plugins/FreeBoy/FreeBoy.h
+++ b/plugins/FreeBoy/FreeBoy.h
@@ -28,8 +28,8 @@
 
 #include <Blip_Buffer.h>
 
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "Graph.h"
 
@@ -47,7 +47,7 @@ class Knob;
 }
 
 
-class FreeBoyInstrument : public Instrument
+class FreeBoyInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -72,7 +72,7 @@ public:
 	void updateKnobToolTip();*/
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	FloatModel m_ch1SweepTimeModel;
 	BoolModel m_ch1SweepDirModel;

--- a/plugins/GigPlayer/GigPlayer.h
+++ b/plugins/GigPlayer/GigPlayer.h
@@ -32,7 +32,7 @@
 #include <QMutexLocker>
 #include <samplerate.h>
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "PixmapButton.h"
 #include "InstrumentView.h"
 #include "Knob.h"
@@ -231,7 +231,7 @@ public:
 
 
 
-class GigInstrument : public Instrument
+class GigInstrument : public DefaultSingleStreamedInstrument
 {
 	Q_OBJECT
 
@@ -268,8 +268,8 @@ public slots:
 
 
 private:
-	void playImpl(std::span<SampleFrame> out) override;
-	void playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out) override;
+	void processImpl(std::span<SampleFrame> out) override;
+	void handleNoteImpl(NotePlayHandle* nph) override;
 
 	// The GIG file and instrument we're using
 	GigInstance * m_instance;

--- a/plugins/Kicker/Kicker.cpp
+++ b/plugins/Kicker/Kicker.cpp
@@ -64,7 +64,7 @@ Plugin::Descriptor PLUGIN_EXPORT kicker_plugin_descriptor =
 
 
 KickerInstrument::KickerInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&kicker_plugin_descriptor, _instrument_track, nullptr, Flag::IsNotBendable),
+	AudioPlugin(&kicker_plugin_descriptor, _instrument_track, nullptr, Flag::IsNotBendable),
 	m_startFreqModel( 150.0f, 5.0f, 1000.0f, 1.0f, this, tr( "Start frequency" ) ),
 	m_endFreqModel( 40.0f, 5.0f, 1000.0f, 1.0f, this, tr( "End frequency" ) ),
 	m_decayModel( 440.0f, 5.0f, 5000.0f, 1.0f, 5000.0f, this, tr( "Length" ) ),
@@ -155,7 +155,7 @@ QString KickerInstrument::nodeName() const
 using DistFX = DspEffectLibrary::Distortion;
 using SweepOsc = KickerOsc<DspEffectLibrary::MonoToStereoAdaptor<DistFX>>;
 
-void KickerInstrument::playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
+void KickerInstrument::processImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
 {
 	const fpp_t frames = nph->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = nph->noteOffset();

--- a/plugins/Kicker/Kicker.h
+++ b/plugins/Kicker/Kicker.h
@@ -26,8 +26,8 @@
 #ifndef LMMS_KICKER_H
 #define LMMS_KICKER_H
 
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "TempoSyncKnobModel.h"
 
@@ -48,7 +48,7 @@ class KickerInstrumentView;
 }
 
 
-class KickerInstrument : public Instrument
+class KickerInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -71,7 +71,7 @@ public:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	FloatModel m_startFreqModel;
 	FloatModel m_endFreqModel;

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -280,7 +280,7 @@ static float computeDecayFactor(float decayTimeInSeconds, float targetedAttenuat
 }
 
 Lb302Synth::Lb302Synth( InstrumentTrack * _instrumentTrack ) :
-	Instrument(&lb302_plugin_descriptor, _instrumentTrack, nullptr, Flag::IsSingleStreamed),
+	AudioPlugin(&lb302_plugin_descriptor, _instrumentTrack, nullptr, Flag::IsSingleStreamed),
 	vcf_cut_knob( 0.75f, 0.0f, 1.5f, 0.005f, this, tr( "VCF Cutoff Frequency" ) ),
 	vcf_res_knob( 0.75f, 0.0f, 1.25f, 0.005f, this, tr( "VCF Resonance" ) ),
 	vcf_mod_knob( 0.1f, 0.0f, 1.0f, 0.005f, this, tr( "VCF Envelope Mod" ) ),
@@ -353,9 +353,6 @@ Lb302Synth::Lb302Synth( InstrumentTrack * _instrumentTrack ) :
 	new_freq = false;
 
 	filterChanged();
-
-	auto iph = new InstrumentPlayHandle(this, _instrumentTrack);
-	Engine::audioEngine()->addPlayHandle( iph );
 }
 
 
@@ -730,7 +727,7 @@ void Lb302Synth::initSlide()
 }
 
 
-void Lb302Synth::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame>)
+void Lb302Synth::handleNoteImpl(NotePlayHandle* _n)
 {
 	if( _n->isMasterNote() || ( _n->hasParent() && _n->isReleased() ) )
 	{
@@ -789,7 +786,7 @@ void Lb302Synth::processNote( NotePlayHandle * _n )
 
 
 
-void Lb302Synth::playImpl(std::span<SampleFrame> out)
+void Lb302Synth::processImpl(std::span<SampleFrame> out)
 {
 	m_notesMutex.lock();
 	while( ! m_notes.isEmpty() )

--- a/plugins/Lb302/Lb302.h
+++ b/plugins/Lb302/Lb302.h
@@ -32,8 +32,8 @@
 #ifndef LB302_H
 #define LB302_H
 
+#include "AudioPlugin.h"
 #include "DspEffectLibrary.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "NotePlayHandle.h"
 #include <QMutex>
@@ -145,7 +145,7 @@ public:
 };
 
 
-class Lb302Synth : public Instrument
+class Lb302Synth : public DefaultSingleStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -162,8 +162,8 @@ public:
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 private:
-	void playImpl(std::span<SampleFrame> out) override;
-	void playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out) override;
+	void processImpl(std::span<SampleFrame> out) override;
+	void handleNoteImpl(NotePlayHandle* nph) override;
 
 	void processNote( NotePlayHandle * n );
 

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -73,7 +73,7 @@ Plugin::Descriptor PLUGIN_EXPORT lv2instrument_plugin_descriptor =
 
 Lv2Instrument::Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 	Descriptor::SubPluginFeatures::Key *key) :
-	Instrument(&lv2instrument_plugin_descriptor, instrumentTrackArg, key,
+	AudioPlugin(&lv2instrument_plugin_descriptor, instrumentTrackArg, key,
 #ifdef LV2_INSTRUMENT_USE_MIDI
 		Flag::IsSingleStreamed | Flag::IsMidiBased
 #else
@@ -88,10 +88,6 @@ Lv2Instrument::Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 		this, SLOT(updatePitchRange()), Qt::DirectConnection);
 	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
 		this, &Lv2Instrument::onSampleRateChanged);
-
-	// now we need a play-handle which cares for calling play()
-	auto iph = new InstrumentPlayHandle(this, instrumentTrackArg);
-	Engine::audioEngine()->addPlayHandle(iph);
 }
 
 
@@ -162,7 +158,7 @@ void Lv2Instrument::loadFile(const QString &file)
 
 
 #ifdef LV2_INSTRUMENT_USE_MIDI
-bool Lv2Instrument::handleMidiEvent(
+bool Lv2Instrument::handleMidiEventImpl(
 	const MidiEvent &event, const TimePos &time, f_cnt_t offset)
 {
 	// this function can be called from GUI threads while the plugin is running
@@ -185,7 +181,7 @@ void Lv2Instrument::playNoteImpl(NotePlayHandle *nph, std::span<SampleFrame>)
 
 
 
-void Lv2Instrument::playImpl(std::span<SampleFrame> out)
+void Lv2Instrument::processImpl(std::span<SampleFrame> out)
 {
 	copyModelsFromLmms();
 

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -28,7 +28,7 @@
 #include <QString>
 #include <array>
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "Lv2ControlBase.h"
 #include "Lv2ViewBase.h"
@@ -48,8 +48,8 @@ class Lv2InsView;
 
 }
 
-// TODO: Add support for pin connector and a variable number of audio input/output ports
-class Lv2Instrument : public Instrument, public Lv2ControlBase
+// TODO: Add multi-channel support
+class Lv2Instrument : public DefaultSingleStreamedMidiInstrument, public Lv2ControlBase
 {
 	Q_OBJECT
 signals:
@@ -76,12 +76,12 @@ public:
 	*/
 	bool hasNoteInput() const override { return Lv2ControlBase::hasNoteInput(); }
 #ifdef LV2_INSTRUMENT_USE_MIDI
-	bool handleMidiEvent(const MidiEvent &event,
+	bool handleMidiEventImpl(const MidiEvent &event,
 		const TimePos &time = TimePos(), f_cnt_t offset = 0) override;
 #else
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame>) override;
+	void handleNoteImpl(NotePlayHandle* nph) override;
 #endif
-	void playImpl(std::span<SampleFrame> out) override;
+	void processImpl(std::span<SampleFrame> out) override;
 
 	/*
 		misc

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -861,7 +861,7 @@ inline sample_t MonstroSynth::calcSlope( int slope, sample_t s )
 
 
 MonstroInstrument::MonstroInstrument( InstrumentTrack * _instrument_track ) :
-		Instrument(&monstro_plugin_descriptor, _instrument_track),
+		AudioPlugin(&monstro_plugin_descriptor, _instrument_track),
 
 		m_osc1Vol(33.f, 0.f, 200.f, 0.1f, this, tr("Osc 1 volume")),
 		m_osc1Pan(0.f, -100.f, 100.f, 0.1f, this, tr("Osc 1 panning")),
@@ -1059,7 +1059,7 @@ MonstroInstrument::MonstroInstrument( InstrumentTrack * _instrument_track ) :
 }
 
 
-void MonstroInstrument::playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
+void MonstroInstrument::processImpl(NotePlayHandle* nph, std::span<SampleFrame> out)
 {
 	const fpp_t frames = nph->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = nph->noteOffset();

--- a/plugins/Monstro/Monstro.h
+++ b/plugins/Monstro/Monstro.h
@@ -28,8 +28,8 @@
 
 #include <vector>
 
+#include "AudioPlugin.h"
 #include "ComboBoxModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "AutomatableModel.h"
 #include "TempoSyncKnob.h"
@@ -317,7 +317,7 @@ private:
 	std::vector<float> m_env[2];
 };
 
-class MonstroInstrument : public Instrument
+class MonstroInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 
@@ -437,7 +437,7 @@ protected:
 	int m_counterMax;
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	inline float leftCh( float _vol, float _pan )
 	{

--- a/plugins/Nes/Nes.cpp
+++ b/plugins/Nes/Nes.cpp
@@ -481,7 +481,7 @@ void NesObject::updatePitch()
 
 
 NesInstrument::NesInstrument( InstrumentTrack * instrumentTrack ) :
-	Instrument(&nes_plugin_descriptor, instrumentTrack),
+	AudioPlugin(&nes_plugin_descriptor, instrumentTrack),
 	m_ch1Enabled(true, this, tr("Channel 1 enable")),
 	m_ch1Crs( 0.f, -24.f, 24.f, 1.f, this, tr( "Channel 1 coarse detune" ) ),
 	m_ch1Volume( 15.f, 0.f, 15.f, 1.f, this, tr( "Channel 1 volume" ) ),
@@ -545,11 +545,11 @@ NesInstrument::NesInstrument( InstrumentTrack * instrumentTrack ) :
 
 
 
-void NesInstrument::playNoteImpl(NotePlayHandle* n, std::span<SampleFrame> out)
+void NesInstrument::processImpl(NotePlayHandle* n, std::span<SampleFrame> out)
 {
 	const fpp_t frames = n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = n->noteOffset();
-	
+
 	if (!n->m_pluginData)
 	{
 		auto nes = new NesObject(this, Engine::audioEngine()->outputSampleRate(), n);
@@ -559,7 +559,7 @@ void NesInstrument::playNoteImpl(NotePlayHandle* n, std::span<SampleFrame> out)
 	auto nes = static_cast<NesObject*>(n->m_pluginData);
 
 	nes->renderOutput(out.data() + offset, frames);
-	
+
 	applyRelease(out.data(), n);
 }
 

--- a/plugins/Nes/Nes.h
+++ b/plugins/Nes/Nes.h
@@ -27,7 +27,7 @@
 
 #include <cmath>
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "AutomatableModel.h"
 #include "PixmapButton.h"
@@ -197,7 +197,7 @@ private:
 };
 
 
-class NesInstrument : public Instrument
+class NesInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -231,7 +231,7 @@ protected:
 	float m_freq3;
 	
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	// channel 1
 	BoolModel	m_ch1Enabled;

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -94,7 +94,7 @@ QMutex OpulenzInstrument::emulatorMutex;
 const auto adlib_opadd = std::array<unsigned int, OPL2_VOICES>{0x00, 0x01, 0x02, 0x08, 0x09, 0x0A, 0x10, 0x11, 0x12};
 
 OpulenzInstrument::OpulenzInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&opulenz_plugin_descriptor, _instrument_track, nullptr, Flag::IsSingleStreamed | Flag::IsMidiBased),
+	AudioPlugin(&opulenz_plugin_descriptor, _instrument_track, nullptr, Flag::IsSingleStreamed | Flag::IsMidiBased),
 	m_patchModel( 0, 0, 127, this, tr( "Patch" ) ),
 	op1_a_mdl(14.0, 0.0, 15.0, 1.0, this, tr( "Op 1 attack" )  ),
 	op1_d_mdl(14.0, 0.0, 15.0, 1.0, this, tr( "Op 1 decay" )   ),
@@ -212,10 +212,6 @@ OpulenzInstrument::OpulenzInstrument( InstrumentTrack * _instrument_track ) :
 	MOD_CON( fm_mdl );
 	MOD_CON( vib_depth_mdl );
 	MOD_CON( trem_depth_mdl );
-
-	// Connect the plugin to the audio engine...
-	auto iph = new InstrumentPlayHandle(this, _instrument_track);
-	Engine::audioEngine()->addPlayHandle( iph );
 }
 
 OpulenzInstrument::~OpulenzInstrument() {
@@ -291,7 +287,7 @@ int OpulenzInstrument::pushVoice(int v) {
 	return i;
 }
 
-bool OpulenzInstrument::handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
+bool OpulenzInstrument::handleMidiEventImpl(const MidiEvent& event, const TimePos& time, f_cnt_t offset)
 {
 	emulatorMutex.lock();
 
@@ -389,7 +385,7 @@ gui::PluginView* OpulenzInstrument::instantiateView( QWidget * _parent )
 }
 
 
-void OpulenzInstrument::playImpl(std::span<SampleFrame> out)
+void OpulenzInstrument::processImpl(std::span<SampleFrame> out)
 {
 	emulatorMutex.lock();
 	theEmulator->update(renderbuffer, frameCount);

--- a/plugins/OpulenZ/OpulenZ.h
+++ b/plugins/OpulenZ/OpulenZ.h
@@ -27,8 +27,8 @@
 
 #include <QMutex>
 
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 
 class Copl;
@@ -54,7 +54,7 @@ class automatableButtonGroup;
 // The "normal" range for LMMS pitchbends
 #define DEFAULT_BEND_CENTS 100
 
-class OpulenzInstrument : public Instrument
+class OpulenzInstrument : public DefaultSingleStreamedMidiInstrument
 {
 	Q_OBJECT
 public:
@@ -63,8 +63,6 @@ public:
 
 	QString nodeName() const override;
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
-
-	bool handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0 ) override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _this ) override;
 	void loadSettings( const QDomElement & _this ) override;
@@ -121,7 +119,8 @@ private slots:
 	void loadGMPatch();
 
 private:
-	void playImpl(std::span<SampleFrame> out) override;
+	void processImpl(std::span<SampleFrame> out) override;
+	bool handleMidiEventImpl(const MidiEvent& event, const TimePos& time, f_cnt_t offset) override;
 
 	Copl *theEmulator;
 	QString storedname;

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -72,7 +72,7 @@ float * OrganicInstrument::s_harmonics = nullptr;
 
 
 OrganicInstrument::OrganicInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&organic_plugin_descriptor, _instrument_track),
+	AudioPlugin(&organic_plugin_descriptor, _instrument_track),
 	m_modulationAlgo(static_cast<int>(Oscillator::ModulationAlgo::SignalMix),
 		static_cast<int>(Oscillator::ModulationAlgo::SignalMix),
 		static_cast<int>(Oscillator::ModulationAlgo::SignalMix)),
@@ -220,7 +220,7 @@ QString OrganicInstrument::nodeName() const
 
 
 
-void OrganicInstrument::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
+void OrganicInstrument::processImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
 {
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();

--- a/plugins/Organic/Organic.h
+++ b/plugins/Organic/Organic.h
@@ -27,7 +27,7 @@
 
 #include <QString>
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "AutomatableModel.h"
 
@@ -117,7 +117,7 @@ private slots:
 } ;
 
 
-class OrganicInstrument : public Instrument
+class OrganicInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -140,7 +140,7 @@ public slots:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	float inline waveshape(float in, float amount);
 

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -80,7 +80,7 @@ PLUGIN_EXPORT Plugin * lmms_plugin_main( Model *m, void * )
 
 
 PatmanInstrument::PatmanInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&patman_plugin_descriptor, _instrument_track),
+	AudioPlugin(&patman_plugin_descriptor, _instrument_track),
 	m_loopedModel( true, this ),
 	m_tunedModel( true, this )
 {
@@ -133,7 +133,7 @@ QString PatmanInstrument::nodeName() const
 
 
 
-void PatmanInstrument::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
+void PatmanInstrument::processImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
 {
 	if( m_patchFile == "" )
 	{

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -26,7 +26,7 @@
 #ifndef PATMAN_H
 #define PATMAN_H
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "Sample.h"
 #include "SampleBuffer.h"
@@ -52,7 +52,7 @@ class PatmanView;
 #define MODES_CLAMPED	( 1 << 7 )
 
 
-class PatmanInstrument : public Instrument
+class PatmanInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -81,7 +81,7 @@ public slots:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	struct handle_data
 	{

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -122,7 +122,7 @@ struct Sf2PluginData
 
 
 Sf2Instrument::Sf2Instrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&sf2player_plugin_descriptor, _instrument_track, nullptr, Flag::IsSingleStreamed),
+	AudioPlugin(&sf2player_plugin_descriptor, _instrument_track, nullptr, Flag::IsSingleStreamed),
 	m_srcState( nullptr ),
 	m_synth(nullptr),
 	m_font( nullptr ),
@@ -220,9 +220,6 @@ Sf2Instrument::Sf2Instrument( InstrumentTrack * _instrument_track ) :
 	connect(instrumentTrack()->microtuner()->keymapModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
 	connect(instrumentTrack()->microtuner()->keyRangeImportModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
 	connect(instrumentTrack()->baseNoteModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
-
-	auto iph = new InstrumentPlayHandle(this, _instrument_track);
-	Engine::audioEngine()->addPlayHandle( iph );
 }
 
 
@@ -661,7 +658,7 @@ void Sf2Instrument::reloadSynth()
 
 
 
-void Sf2Instrument::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame>)
+void Sf2Instrument::handleNoteImpl(NotePlayHandle* _n)
 {
 	if( _n->isMasterNote() || ( _n->hasParent() && _n->isReleased() ) )
 	{
@@ -796,7 +793,7 @@ void Sf2Instrument::noteOff( Sf2PluginData * n )
 }
 
 
-void Sf2Instrument::playImpl(std::span<SampleFrame> out)
+void Sf2Instrument::processImpl(std::span<SampleFrame> out)
 {
 	// set midi pitch for this period
 	const int currentMidiPitch = instrumentTrack()->midiPitch();

--- a/plugins/Sf2Player/Sf2Player.h
+++ b/plugins/Sf2Player/Sf2Player.h
@@ -32,7 +32,7 @@
 #include <QMutex>
 #include <samplerate.h>
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "LcdSpinBox.h"
 
@@ -55,7 +55,7 @@ class PatchesDialog;
 } // namespace gui
 
 
-class Sf2Instrument : public Instrument
+class Sf2Instrument : public DefaultSingleStreamedInstrument
 {
 	Q_OBJECT
 	mapPropertyFromModel(int,getBank,setBank,m_bankNum);
@@ -99,8 +99,8 @@ public slots:
 	void updateTuning();
 
 private:
-	void playImpl(std::span<SampleFrame> out) override;
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(std::span<SampleFrame> out) override;
+	void handleNoteImpl(NotePlayHandle* nph) override;
 
 	SRC_STATE * m_srcState;
 

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -322,7 +322,7 @@ bool SfxrSynth::isPlaying() const
 
 
 SfxrInstrument::SfxrInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&sfxr_plugin_descriptor, _instrument_track),
+	AudioPlugin(&sfxr_plugin_descriptor, _instrument_track),
 	m_attModel(0.0f, this, "Attack Time"),
 	m_holdModel(0.3f, this, "Sustain Time"),
 	m_susModel(0.0f, this, "Sustain Punch"),
@@ -443,7 +443,7 @@ QString SfxrInstrument::nodeName() const
 
 
 
-void SfxrInstrument::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
+void SfxrInstrument::processImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
 {
 	float currentSampleRate = Engine::audioEngine()->outputSampleRate();
 

--- a/plugins/Sfxr/Sfxr.h
+++ b/plugins/Sfxr/Sfxr.h
@@ -30,8 +30,8 @@
 
 #include <array>
 
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 
 namespace lmms
@@ -172,7 +172,7 @@ public:
 	}
 };
 
-class SfxrInstrument : public Instrument
+class SfxrInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -193,7 +193,7 @@ public:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	SfxrZeroToOneFloatModel m_attModel;
 	SfxrZeroToOneFloatModel m_holdModel;

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -117,7 +117,7 @@ VoiceObject::VoiceObject( Model * _parent, int _idx ) :
 
 
 SidInstrument::SidInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument(&sid_plugin_descriptor, _instrument_track),
+	AudioPlugin(&sid_plugin_descriptor, _instrument_track),
 	// filter
 	m_filterFCModel( 1024.0f, 0.0f, 2047.0f, 1.0f, this, tr( "Cutoff frequency" ) ),
 	m_filterResonanceModel( 8.0f, 0.0f, 15.0f, 1.0f, this, tr( "Resonance" ) ),
@@ -289,7 +289,7 @@ static int sid_fillbuffer(unsigned char* sidreg, reSID::SID *sid, int tdelta, sh
 
 
 // TODO: The real sample type is `short` and there is only one output channel
-void SidInstrument::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
+void SidInstrument::processImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
 {
 	const int clockrate = C64_PAL_CYCLES_PER_SEC;
 	const int samplerate = Engine::audioEngine()->outputSampleRate();

--- a/plugins/Sid/SidInstrument.h
+++ b/plugins/Sid/SidInstrument.h
@@ -79,7 +79,7 @@ private:
 	friend class gui::SidInstrumentView;
 } ;
 
-class SidInstrument : public Instrument
+class SidInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -118,7 +118,7 @@ public:
 	void updateKnobToolTip();*/
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	// voices
 	VoiceObject * m_voice[3];

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -56,7 +56,7 @@ Plugin::Descriptor PLUGIN_EXPORT slicert_plugin_descriptor = {
 // ################################# SlicerT ####################################
 
 SlicerT::SlicerT(InstrumentTrack* instrumentTrack)
-	: Instrument(&slicert_plugin_descriptor, instrumentTrack)
+	: AudioPlugin(&slicert_plugin_descriptor, instrumentTrack)
 	, m_noteThreshold(0.6f, 0.0f, 2.0f, 0.01f, this, tr("Note threshold"))
 	, m_fadeOutFrames(10.0f, 0.0f, 100.0f, 0.1f, this, tr("FadeOut"))
 	, m_originalBPM(1, 1, 999, this, tr("Original bpm"))
@@ -75,7 +75,7 @@ SlicerT::SlicerT(InstrumentTrack* instrumentTrack)
 	m_sliceSnap.setValue(0);
 }
 
-void SlicerT::playNoteImpl(NotePlayHandle* handle, std::span<SampleFrame> out)
+void SlicerT::processImpl(NotePlayHandle* handle, std::span<SampleFrame> out)
 {
 	if (m_originalSample.sampleSize() <= 1) { return; }
 

--- a/plugins/SlicerT/SlicerT.h
+++ b/plugins/SlicerT/SlicerT.h
@@ -29,8 +29,8 @@
 #include <fftw3.h>
 #include <stdexcept>
 
+#include "AudioPlugin.h"
 #include "AutomatableModel.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "Note.h"
 #include "Sample.h"
@@ -61,7 +61,7 @@ private:
 	SRC_STATE* m_resamplingState;
 };
 
-class SlicerT : public Instrument
+class SlicerT : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 
@@ -91,7 +91,7 @@ public:
 	std::vector<Note> getMidi();
 
 private:
-	void playNoteImpl(NotePlayHandle* handle, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* handle, std::span<SampleFrame> out) override;
 
 	FloatModel m_noteThreshold;
 	FloatModel m_fadeOutFrames;

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -69,7 +69,7 @@ Plugin::Descriptor PLUGIN_EXPORT malletsstk_plugin_descriptor =
 
 
 MalletsInstrument::MalletsInstrument( InstrumentTrack * _instrument_track ):
-	Instrument(&malletsstk_plugin_descriptor, _instrument_track),
+	AudioPlugin(&malletsstk_plugin_descriptor, _instrument_track),
 	m_hardnessModel(64.0f, 0.0f, 128.0f, 0.1f, this, tr( "Hardness" )),
 	m_positionModel(64.0f, 0.0f, 64.0f, 0.1f, this, tr( "Position" )),
 	m_vibratoGainModel(0.0f, 0.0f, 128.0f, 0.1f, this, tr( "Vibrato gain" )),
@@ -278,7 +278,7 @@ QString MalletsInstrument::nodeName() const
 
 
 
-void MalletsInstrument::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
+void MalletsInstrument::processImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
 {
 	if( m_filesMissing )
 	{

--- a/plugins/Stk/Mallets/Mallets.h
+++ b/plugins/Stk/Mallets/Mallets.h
@@ -29,8 +29,8 @@
 
 #include <stk/Instrmnt.h>
 
+#include "AudioPlugin.h"
 #include "ComboBox.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 #include "Knob.h"
 #include "NotePlayHandle.h"
@@ -181,7 +181,7 @@ protected:
 
 
 
-class MalletsInstrument : public Instrument
+class MalletsInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -199,7 +199,7 @@ public:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	FloatModel m_hardnessModel;
 	FloatModel m_positionModel;

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -213,7 +213,7 @@ void OscillatorObject::updateUseWaveTable()
 
 
 TripleOscillator::TripleOscillator( InstrumentTrack * _instrument_track ) :
-	Instrument(&tripleoscillator_plugin_descriptor, _instrument_track)
+	AudioPlugin(&tripleoscillator_plugin_descriptor, _instrument_track)
 {
 	for( int i = 0; i < NUM_OF_OSCILLATORS; ++i )
 	{
@@ -303,7 +303,7 @@ QString TripleOscillator::nodeName() const
 
 
 
-void TripleOscillator::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
+void TripleOscillator::processImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
 {
 	if (!_n->m_pluginData)
 	{

--- a/plugins/TripleOscillator/TripleOscillator.h
+++ b/plugins/TripleOscillator/TripleOscillator.h
@@ -28,7 +28,7 @@
 
 #include <memory>
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "AutomatableModel.h"
 #include "OscillatorConstants.h"
@@ -104,7 +104,7 @@ private slots:
 
 
 
-class TripleOscillator : public Instrument
+class TripleOscillator : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -131,7 +131,7 @@ protected slots:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* _n, std::span<SampleFrame> out) override;
 
 	OscillatorObject * m_osc[NUM_OF_OSCILLATORS];
 

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -165,10 +165,6 @@ VestigeInstrument::VestigeInstrument( InstrumentTrack * _instrument_track ) :
 	knobFModel( nullptr ),
 	p_subWindow( nullptr )
 {
-	// now we need a play-handle which cares for calling play()
-	auto iph = new InstrumentPlayHandle(this, _instrument_track);
-	Engine::audioEngine()->addPlayHandle( iph );
-
 	connect( ConfigManager::inst(), SIGNAL( valueChanged(QString,QString,QString) ),
 			 this, SLOT( handleConfigChange(QString, QString, QString) ),
 			 Qt::QueuedConnection );
@@ -418,7 +414,7 @@ void VestigeInstrument::processImpl()
 
 
 
-bool VestigeInstrument::handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
+bool VestigeInstrument::handleMidiEventImpl(const MidiEvent& event, const TimePos& time, f_cnt_t offset)
 {
 	m_pluginMutex.lock();
 	if( m_plugin != nullptr )

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -76,7 +76,7 @@ public:
 };
 
 class VestigeInstrument
-	: public AudioPlugin<Instrument, VestigeSettings, VestigeAudioPorts>
+	: public AudioPlugin<SingleStreamedMidiInstrument, VestigeSettings, VestigeAudioPorts>
 {
 	Q_OBJECT
 public:
@@ -90,7 +90,7 @@ public:
 
 	void loadFile(const QString& _file) override;
 
-	bool handleMidiEvent(const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0) override;
+	bool handleMidiEventImpl(const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0) override;
 
 	gui::PluginView* instantiateView(QWidget* _parent) override;
 

--- a/plugins/Vibed/Vibed.cpp
+++ b/plugins/Vibed/Vibed.cpp
@@ -97,7 +97,7 @@ private:
 };
 
 Vibed::Vibed(InstrumentTrack* instrumentTrack) :
-	Instrument(&vibedstrings_plugin_descriptor, instrumentTrack, nullptr, Flag::IsNotBendable)
+	AudioPlugin(&vibedstrings_plugin_descriptor, instrumentTrack, nullptr, Flag::IsNotBendable)
 {
 	for (int harm = 0; harm < s_stringCount; ++harm)
 	{
@@ -201,7 +201,7 @@ QString Vibed::nodeName() const
 	return vibedstrings_plugin_descriptor.name;
 }
 
-void Vibed::playNoteImpl(NotePlayHandle* n, std::span<SampleFrame> out)
+void Vibed::processImpl(NotePlayHandle* n, std::span<SampleFrame> out)
 {
 	if (!n->m_pluginData)
 	{

--- a/plugins/Vibed/Vibed.h
+++ b/plugins/Vibed/Vibed.h
@@ -25,7 +25,7 @@
 #ifndef LMMS_VIBED_H
 #define LMMS_VIBED_H
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "NineButtonSelector.h"
 #include "Knob.h"
@@ -50,7 +50,7 @@ class LedCheckBox;
 class VibedView;
 }
 
-class Vibed : public Instrument
+class Vibed : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -67,7 +67,7 @@ public:
 	gui::PluginView* instantiateView(QWidget* parent) override;
 
 private:
-	void playNoteImpl(NotePlayHandle* n, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* n, std::span<SampleFrame> out) override;
 
 	class StringContainer;
 

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -248,7 +248,7 @@ void WatsynObject::renderOutput( fpp_t _frames )
 
 
 WatsynInstrument::WatsynInstrument( InstrumentTrack * _instrument_track ) :
-		Instrument(&watsyn_plugin_descriptor, _instrument_track),
+		AudioPlugin(&watsyn_plugin_descriptor, _instrument_track),
 
 		a1_vol( 100.0f, 0.0f, 200.0f, 0.1f, this, tr( "Volume A1" ) ),
 		a2_vol( 100.0f, 0.0f, 200.0f, 0.1f, this, tr( "Volume A2" ) ),
@@ -341,7 +341,7 @@ WatsynInstrument::WatsynInstrument( InstrumentTrack * _instrument_track ) :
 }
 
 
-void WatsynInstrument::playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
+void WatsynInstrument::processImpl(NotePlayHandle* _n, std::span<SampleFrame> out)
 {
 	if (!_n->m_pluginData)
 	{

--- a/plugins/Watsyn/Watsyn.h
+++ b/plugins/Watsyn/Watsyn.h
@@ -26,7 +26,7 @@
 #ifndef WATSYN_H
 #define WATSYN_H
 
-#include "Instrument.h"
+#include "AudioPlugin.h"
 #include "InstrumentView.h"
 #include "Graph.h"
 #include "AutomatableModel.h"
@@ -132,7 +132,7 @@ private:
 	float m_B2wave [WAVELEN];
 };
 
-class WatsynInstrument : public Instrument
+class WatsynInstrument : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -173,7 +173,7 @@ protected:
 	float m_rfreq [NUM_OSCS];
 
 private:
-	void playNoteImpl(NotePlayHandle* _n, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* _n, std::span<SampleFrame> out) override;
 
 	inline float leftCh( float _vol, float _pan )
 	{

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -78,7 +78,7 @@ O2 -> trianglew(2t*f)*(0.5+0.5sinew(12*A1*t))+sinew(t*f)*(0.5+0.5sinew(12*A1*t+0
 #define GRAPH_LENGTH 4096
 
 Xpressive::Xpressive(InstrumentTrack* instrument_track) :
-	Instrument(&xpressive_plugin_descriptor, instrument_track),
+	AudioPlugin(&xpressive_plugin_descriptor, instrument_track),
 	m_graphO1(-1.0f, 1.0f, 360, this),
 	m_graphO2(-1.0f, 1.0f, 360, this),
 	m_graphW1(-1.0f, 1.0f, GRAPH_LENGTH, this),
@@ -194,7 +194,7 @@ QString Xpressive::nodeName() const {
 	return (xpressive_plugin_descriptor.name);
 }
 
-void Xpressive::playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) {
+void Xpressive::processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) {
 	m_A1=m_parameterA1.value();
 	m_A2=m_parameterA2.value();
 	m_A3=m_parameterA3.value();

--- a/plugins/Xpressive/Xpressive.h
+++ b/plugins/Xpressive/Xpressive.h
@@ -29,8 +29,8 @@
 
 #include <QTextEdit>
 
+#include "AudioPlugin.h"
 #include "Graph.h"
-#include "Instrument.h"
 #include "InstrumentView.h"
 
 #include "ExprSynth.h"
@@ -61,7 +61,7 @@ class XpressiveView;
 
 
 
-class Xpressive : public Instrument
+class Xpressive : public DefaultMultiStreamedInstrument
 {
 	Q_OBJECT
 public:
@@ -112,7 +112,7 @@ protected slots:
 
 
 private:
-	void playNoteImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
+	void processImpl(NotePlayHandle* nph, std::span<SampleFrame> out) override;
 
 	graphModel  m_graphO1;
 	graphModel  m_graphO2;

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -132,10 +132,6 @@ ZynAddSubFxInstrument::ZynAddSubFxInstrument(
 	connect( &m_resBandwidthModel, SIGNAL( dataChanged() ),
 			this, SLOT( updateResBandwidth() ), Qt::DirectConnection );
 
-	// now we need a play-handle which cares for calling play()
-	auto iph = new InstrumentPlayHandle(this, _instrumentTrack);
-	Engine::audioEngine()->addPlayHandle( iph );
-
 	connect( Engine::audioEngine(), SIGNAL( sampleRateChanged() ),
 			this, SLOT( reloadPlugin() ) );
 
@@ -344,7 +340,7 @@ void ZynAddSubFxInstrument::processImpl()
 
 
 
-bool ZynAddSubFxInstrument::handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
+bool ZynAddSubFxInstrument::handleMidiEventImpl(const MidiEvent& event, const TimePos& time, f_cnt_t offset)
 {
 	// do not forward external MIDI Control Change events if the according
 	// LED is not checked

--- a/plugins/ZynAddSubFx/ZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.h
@@ -69,7 +69,7 @@ signals:
 
 
 class ZynAddSubFxInstrument
-	: public AudioPluginExt<Instrument, AudioPortsSettings {
+	: public AudioPluginExt<SingleStreamedMidiInstrument, AudioPortsSettings {
 			.kind = AudioDataKind::F32,
 			.interleaved = false,
 			.inputs = 0,
@@ -81,7 +81,7 @@ public:
 	ZynAddSubFxInstrument( InstrumentTrack * _instrument_track );
 	~ZynAddSubFxInstrument() override;
 
-	bool handleMidiEvent( const MidiEvent& event, const TimePos& time = TimePos(), f_cnt_t offset = 0 ) override;
+	bool handleMidiEventImpl(const MidiEvent& event, const TimePos& time, f_cnt_t offset) override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 	void loadSettings( const QDomElement & _this ) override;

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -31,6 +31,7 @@
 #include "DummyInstrument.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
+#include "InstrumentPlayHandle.h"
 #include "LmmsTypes.h"
 
 namespace lmms
@@ -57,8 +58,15 @@ Instrument *Instrument::instantiate(const QString &_plugin_name,
 		Q_ASSERT(!key);
 	// copy from above // TODO! common cleaner func
 	Plugin * p = Plugin::instantiateWithKey(_plugin_name, _instrument_track, key, keyFromDnd);
-	if(dynamic_cast<Instrument *>(p))
-		return dynamic_cast<Instrument *>(p);
+	if (auto inst = dynamic_cast<Instrument*>(p))
+	{
+		if (auto ssInst = dynamic_cast<SingleStreamedInstrument*>(inst))
+		{
+			auto iph = new InstrumentPlayHandle{ssInst};
+			Engine::audioEngine()->addPlayHandle(iph);
+		}
+		return inst;
+	}
 	delete p;
 	return( new DummyInstrument( _instrument_track ) );
 }

--- a/src/core/InstrumentPlayHandle.cpp
+++ b/src/core/InstrumentPlayHandle.cpp
@@ -33,11 +33,11 @@ namespace lmms
 {
 
 
-InstrumentPlayHandle::InstrumentPlayHandle(Instrument * instrument, InstrumentTrack* instrumentTrack) :
-	PlayHandle(Type::InstrumentPlayHandle),
-	m_instrument(instrument)
+InstrumentPlayHandle::InstrumentPlayHandle(SingleStreamedInstrument* instrument)
+	: PlayHandle(Type::InstrumentPlayHandle)
+	, m_instrument(instrument)
 {
-	setAudioBusHandle(instrumentTrack->audioBusHandle());
+	setAudioBusHandle(instrument->instrumentTrack()->audioBusHandle());
 }
 
 void InstrumentPlayHandle::play(std::span<SampleFrame> buffer)
@@ -62,7 +62,7 @@ void InstrumentPlayHandle::play(std::span<SampleFrame> buffer)
 	}
 	while (nphsLeft);
 
-	m_instrument->play(buffer);
+	m_instrument->processCore(buffer);
 
 	// Process the audio buffer that the instrument has just worked on...
 	instrumentTrack->processAudioBuffer(buffer.data(), buffer.size(), nullptr);

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -586,7 +586,18 @@ void InstrumentTrack::playNote(NotePlayHandle* n, std::span<SampleFrame> working
 	if( n->isMasterNote() == false && m_instrument != nullptr )
 	{
 		// all is done, so now lets play the note!
-		m_instrument->playNote( n, workingBuffer );
+		if (auto ssInst = dynamic_cast<SingleStreamedInstrument*>(m_instrument))
+		{
+			ssInst->handleNote(n);
+		}
+		else if (auto msInst = dynamic_cast<MultiStreamedInstrument*>(m_instrument))
+		{
+			msInst->processCore(n, workingBuffer);
+		}
+		else
+		{
+			throw std::runtime_error{"InstrumentTrack::playNote - unexpected!"};
+		}
 
 		// This is effectively the same as checking if workingBuffer is not a nullptr.
 		// Calling processAudioBuffer with a nullptr leads to crashes. Hence the check.


### PR DESCRIPTION
All single-streamed instruments (Carla, Gig Player, Lb302, LV2, OpulenZ, Sf2Player, Vestige, and Zyn) now have full pin connector support (though not necessarily multi-channel support yet).

The rest of the instruments ("multi-streamed" instruments) also use the pin connector internally, though for now the GUI is disabled so that only the default pin configuration can be used. This is because multi-streamed instruments are improperly using the audio port's buffer rather than the `NotePlayHandle`'s buffer which causes audio glitches due to `processImpl` being called concurrently from multiple threads. It only works when the pin connector is in its default configuration because the "direct routing" optimization lets it avoid using the audio port buffers entirely.

### Changes
- Use `AudioPlugin` (and therefore the pin connector) for all instruments
- Added some new classes:
  - `SingleStreamedInstrument`
  - `SingleStreamedMidiInstrument`
  - `MultiStreamedInstrument` 
- Added `Default*` type aliases for the different kinds of instruments
- Moved `InstrumentPlayHandle` creating to `Instrument::instantiate()` rather than expecting all single-streamed instruments to add their own play handle themselves

### New classes:
- `SingleStreamedInstrument`
- `SingleStreamedMidiInstrument`
- `MultiStreamedInstrument`

These classes allow `Instrument::Flag::IsSingleStreamed` and `Instrument::Flag::IsMidiBased` to be specified by instrument plugins at compile time. Then different process methods are able to be offered based on that choice.

Previously both single-streamed instruments and multi-streamed instruments used this method:
```cpp
void playNote(NotePlayHandle* nph, std::span<SampleFrame> out);
```

The purpose and usage of this method was very different depending on whether a plugin was single-streamed or multi-streamed which was very confusing and bad.

For single-streamed instruments, the `out` buffer was always null and unused. The purpose was not to render audio, but only to register that the note `nph` was playing. This is analogous to `handleMidiEvent()` but for `NotePlayHandle`-based instruments.

For multi-streamed instruments, `nph` was also the currently playing note, but `out` was the `NotePlayHandle`'s buffer and the purpose was to render audio to it. In other words, it was the process method for multi-streamed instruments.

To fix this problem, the method was split into two different methods - one in `SingleStreamedInstrument` and another in `MultiStreamedInstrument`:
```cpp
// in SingleStreamedInstrument
void handleNote(NotePlayHandle* nph);

// in MultiStreamedInstrument
void processCore(NotePlayHandle* nph, std::span<SampleFrame> coreInOut);
```

### TODO (this PR):
- Remove `Instrument::Flag`? Or set the single-streamed and MIDI-based flags in constructors?
- Rename `InstrumentPlayHandle` to `SingleStreamedInstrumentPlayHandle`? (because only single-streamed instruments use it)
- Move the `InstrumentPlayHandle` removal code to `SingleStreamedInstrument`? (it shouldn't be the plugin implementation's responsibility)
- Now that the Core calls `processCore`, should the plugin's process method be renamed from `processImpl` to `process`?